### PR TITLE
Add proper parsing and printing of Liquid filters

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -100,7 +100,7 @@ LiquidHTML {
   // because we'd otherwise positively match the following string
   // instead of falling back to the other rule:
   // {{ 'string' | some_filter }}
-  liquidVariable = liquidExpression space* &("-}}" | "}}") // liquidFilter*
+  liquidVariable = liquidExpression liquidFilter* space* &("-}}" | "}}")
 
   liquidExpression =
     | liquidString
@@ -130,12 +130,21 @@ LiquidHTML {
     "(" space* liquidExpression space* ".." space* liquidExpression space* ")"
 
   liquidVariableLookup = variableSegment? lookup*
-  variableSegment = (letter | "_") identifierCharacter*
   lookup =
-    | dotLookup
     | indexLookup
-  dotLookup = space* "." space* variableSegment "?"?
+    | dotLookup
   indexLookup = space* "[" space* liquidExpression space* "]"
+  dotLookup = space* "." space* identifier
+
+  liquidFilter = space* "|" space* identifier (space* ":" space* filterArguments)?
+  filterSeparator = space* "," space*
+  filterArguments = listOf<filterArgument, filterSeparator>
+  filterArgument = namedArgument | positionalArgument
+  positionalArgument = liquidExpression
+  namedArgument = variableSegment space* ":" space* liquidExpression
+
+  variableSegment = (letter | "_") identifierCharacter*
+  identifier = variableSegment "?"?
 
   // https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
   // Cheating a bit with by stretching it to the doctype

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -81,6 +81,8 @@ function getCssDisplay(
       return 'block';
 
     case NodeTypes.LiquidVariable:
+    case NodeTypes.LiquidFilter:
+    case NodeTypes.NamedArgument:
     case NodeTypes.LiquidLiteral:
     case NodeTypes.String:
     case NodeTypes.Number:
@@ -131,6 +133,8 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
       return CSS_WHITE_SPACE_DEFAULT;
 
     case NodeTypes.LiquidVariable:
+    case NodeTypes.LiquidFilter:
+    case NodeTypes.NamedArgument:
     case NodeTypes.LiquidLiteral:
     case NodeTypes.String:
     case NodeTypes.Number:

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -52,12 +52,12 @@ export function printLiquidDrop(
   );
 
   if (typeof node.markup !== 'string') {
+    const whitespace = node.markup.filters.length > 0 ? line : ' ';
     return group([
       '{{',
       whitespaceStart,
-      ' ',
-      path.call(print, 'markup'),
-      ' ',
+      indent([whitespace, path.call(print, 'markup')]),
+      whitespace,
       whitespaceEnd,
       '}}',
     ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export enum NodeTypes {
   TextNode = 'TextNode',
 
   LiquidVariable = 'LiquidVariable',
+  LiquidFilter = 'LiquidFilter',
+  NamedArgument = 'NamedArgument',
   LiquidLiteral = 'LiquidLiteral',
   String = 'String',
   Number = 'Number',

--- a/test/liquid-drop-filters/fixed.liquid
+++ b/test/liquid-drop-filters/fixed.liquid
@@ -1,0 +1,81 @@
+It should never break a name
+printWidth: 1
+{{ x }}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{{
+  x
+  | filter1
+  | filter2
+}}
+
+It should break and indent named arguments
+printWidth: 1
+{{
+  x
+  | filter1:
+    key1: value1,
+    key2: value2
+  | filter2
+}}
+
+It should not break the first positional argument
+printWidth: 1
+{{
+  x
+  | filter1: arg1
+  | filter2: arg2,
+    arg3,
+    arg4
+}}
+
+It should break arguments only if necessary
+printWidth: 40
+{{
+  x
+  | filter1: key1: value1, key2: value2
+  | filter2
+}}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{{
+  x
+  | filter1: pos1,
+    pos2,
+    key1: val1,
+    key2: val2
+}}
+
+It should support a mix of positional and named arguments as expected (p40)
+printWidth: 50
+{{
+  x
+  | filter1: pos1, pos2, key1: val1, key2: val2
+}}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{{ x | filter1: pos1, pos2, key1: val1, key2: val2 }}
+
+It should support all types of arguments
+{{ x | f: 'string' }}
+{{ x | f: 'string' }}
+{{ x | f: 0.0 }}
+{{ x | f: 0 }}
+{{ x | f: x }}
+{{ x | f: (0..a) }}
+{{ x | f: true }}
+
+It should support all types of named arguments, and add spaces
+{{ x | f: key: 'string' }}
+{{ x | f: key: 'string' }}
+{{ x | f: key: 0.0 }}
+{{ x | f: key: 0 }}
+{{ x | f: key: x }}
+{{ x | f: key: (0..a) }}
+{{ x | f: key: true }}
+
+It should support spaces or lack of thereof erywhere
+{{ x | f: a: b, range: (a..b) }}

--- a/test/liquid-drop-filters/index.liquid
+++ b/test/liquid-drop-filters/index.liquid
@@ -1,0 +1,55 @@
+It should never break a name
+printWidth: 1
+{{ x }}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{{ x | filter1 | filter2 }}
+
+It should break and indent named arguments
+printWidth: 1
+{{ x | filter1: key1: value1, key2: value2 | filter2 }}
+
+It should not break the first positional argument
+printWidth: 1
+{{ x | filter1: arg1 | filter2: arg2, arg3, arg4 }}
+
+It should break arguments only if necessary
+printWidth: 40
+{{ x | filter1: key1: value1, key2: value2 | filter2 }}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{{ x | filter1: pos1, pos2, key1: val1, key2: val2 }}
+
+It should support a mix of positional and named arguments as expected (p50)
+printWidth: 50
+{{ x | filter1: pos1, pos2, key1: val1, key2: val2 }}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{{ x | filter1: pos1, pos2, key1: val1, key2: val2 }}
+
+It should support all types of arguments, and add spaces
+{{ x|f:'string' }}
+{{ x|f:"string" }}
+{{ x|f:0.0 }}
+{{ x|f:0 }}
+{{ x|f:x }}
+{{ x|f:(0..a) }}
+{{ x|f:true }}
+
+It should support all types of named arguments, and add spaces
+{{ x|f:key:'string' }}
+{{ x|f:key:"string" }}
+{{ x|f:key:0.0 }}
+{{ x|f:key:0 }}
+{{ x|f:key:x }}
+{{ x|f:key:(0..a) }}
+{{ x|f:key:true }}
+
+It should support spaces or lack of thereof erywhere
+{{ x|f:
+a    :  b  , range
+: ( a .. b)
+}}

--- a/test/liquid-drop-filters/index.spec.ts
+++ b/test/liquid-drop-filters/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/whitespace-breaking-logic-between-liquid-and-text-nodes/index.liquid
+++ b/test/whitespace-breaking-logic-between-liquid-and-text-nodes/index.liquid
@@ -9,6 +9,7 @@ it should break between text and node when the group wouldn't fit on a line
 </p>
 
 it should break between text and node when the child has linebreaks
+printWidth: 30
 <p>
   |============={{
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'


### PR DESCRIPTION
In this PR:

- Adds support for parsing filters inside Liquid drops.
- Prints expression as they are printed in #41
- Adds opinionated logic for when to break filters, and when to break filter arguments

```Liquid
input: (printWidth: 1)
{{ x | filter1 | filter2: pos1, pos2, "hi" | filter3: key1: val1 }}

output:
{{
  x
  | filter1
  | filter2: pos1,
    pos2,
    "hi"
  | filter3:
    key1: val1
 }}
```

Fixes #45

Also, a [quick poll on the partner slack](https://shopifypartners.slack.com/archives/C4E704GBX/p1659634182651679) seems to indicate _most_ folks prefer breaking the tag delimiters on an empty line.

<img src="https://user-images.githubusercontent.com/4990691/183115699-8e1f4f16-6931-49cf-aa66-beb4312ad501.png" width=500>

I'm going to go forward with that style for now and leave folks to vote on a config to support the other style (in alignment with our [opinionated](https://github.com/Shopify/prettier-plugin-liquid/blob/main/docs/principles/opinionated.md) guiding principle) in a separate issue. 
