### PR TITLE
Add proper support of `assign` and `echo` tags

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -79,6 +79,7 @@ LiquidHTML {
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
     | liquidTagEcho
+    | liquidTagAssign
     | liquidTagBaseCase
 
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
@@ -86,6 +87,9 @@ LiquidHTML {
 
   liquidTagEcho = liquidTagRule<"echo", liquidTagEchoMarkup>
   liquidTagEchoMarkup = liquidVariable
+
+  liquidTagAssign = liquidTagRule<"assign", liquidTagAssignMarkup>
+  liquidTagAssignMarkup = variableSegment space* "=" space* liquidVariable
 
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -78,10 +78,14 @@ LiquidHTML {
   liquidTagOpen = "{%" "-"? space* blockName space* tagMarkup "-"? "%}"
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
+    | liquidTagEcho
     | liquidTagBaseCase
 
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
-  liquidTagRule<name, markup> = "{%" "-"? space* name space? markup "-"? "%}"
+  liquidTagRule<name, markup> = "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
+
+  liquidTagEcho = liquidTagRule<"echo", liquidTagEchoMarkup>
+  liquidTagEchoMarkup = liquidVariable
 
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase
@@ -108,7 +112,7 @@ LiquidHTML {
   // because we'd otherwise positively match the following string
   // instead of falling back to the other rule:
   // {{ 'string' | some_filter }}
-  liquidVariable = liquidExpression liquidFilter* space* &("-}}" | "}}")
+  liquidVariable = liquidExpression liquidFilter* space* &("-}}" | "}}" | "-%}" | "%}")
 
   liquidExpression =
     | liquidString

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -77,7 +77,12 @@ LiquidHTML {
 
   liquidTagOpen = "{%" "-"? space* blockName space* tagMarkup "-"? "%}"
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
-  liquidTag = "{%" "-"? space* liquidTagName space? tagMarkup "-"? "%}"
+  liquidTag =
+    | liquidTagBaseCase
+
+  liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
+  liquidTagRule<name, markup> = "{%" "-"? space* name space? markup "-"? "%}"
+
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase
   liquidDropBaseCase = anyExceptStar<("-}}" | "}}")>

--- a/src/parser/ast.spec.ts
+++ b/src/parser/ast.spec.ts
@@ -311,6 +311,41 @@ describe('Unit: toLiquidHtmlAST', () => {
         expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
         expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
         expectPosition(ast, 'children.0');
+        expectPosition(ast, 'children.0.markup');
+        expectPosition(ast, 'children.0.markup.expression');
+      });
+    });
+
+    it('should parse assign tags', () => {
+      [
+        {
+          expression: `x = "hi"`,
+          name: 'x',
+          expressionType: 'String',
+          expressionValue: 'hi',
+          filters: [],
+        },
+        { expression: `z = y | f`, name: 'z', expressionType: 'VariableLookup', filters: ['f'] },
+      ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
+        ast = toLiquidHtmlAST(`{% assign ${expression} -%}`);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+        expectPath(ast, 'children.0.name').to.eql('assign');
+        expectPath(ast, 'children.0.markup.type').to.eql('AssignMarkup');
+        expectPath(ast, 'children.0.markup.name').to.eql(name);
+        expectPath(ast, 'children.0.markup.value.expression.type').to.eql(expressionType);
+        if (expressionValue)
+          expectPath(ast, 'children.0.markup.value.expression.value').to.eql(expressionValue);
+        expectPath(ast, 'children.0.markup.value.filters').to.have.lengthOf(filters.length);
+        expectPath(ast, 'children.0.children').to.be.undefined;
+        expectPath(ast, 'children.0.whitespaceStart').to.eql('');
+        expectPath(ast, 'children.0.whitespaceEnd').to.eql('-');
+        expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
+        expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
+        expectPosition(ast, 'children.0');
+        expectPosition(ast, 'children.0.markup');
+        expectPosition(ast, 'children.0.markup.value');
+        expectPosition(ast, 'children.0.markup.value.expression');
       });
     });
   });

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -19,6 +19,8 @@ import {
   ConcreteLiquidFilter,
   ConcreteLiquidExpression,
   ConcreteLiquidNamedArgument,
+  ConcreteLiquidTagNamed,
+  ConcreteLiquidTag,
 } from '~/parser/cst';
 import { isLiquidHtmlNode, NodeTypes, Position } from '~/types';
 import { assertNever, deepGet, dropLast } from '~/utils';
@@ -88,16 +90,20 @@ export interface LiquidRawTag extends ASTNode<NodeTypes.LiquidRawTag> {
   blockEndPosition: Position;
 }
 
-export interface LiquidTag extends ASTNode<NodeTypes.LiquidTag> {
+export type LiquidTag = LiquidTagNamed | LiquidTagBaseCase;
+export type LiquidTagNamed = LiquidTagEcho;
+
+export interface LiquidTagNode<Name, Markup>
+  extends ASTNode<NodeTypes.LiquidTag> {
   /**
    * e.g. if, ifchanged, for, etc.
    */
-  name: string;
+  name: Name;
 
   /**
-   * The body of the tag. May contain arguments. Excludes the name of the tag. Left trimmed.
+   * The body of the tag. May contain arguments. Excludes the name of the tag. Left trimmed if string.
    */
-  markup: string;
+  markup: Markup;
   children?: LiquidHtmlNode[];
   whitespaceStart: '-' | '';
   whitespaceEnd: '-' | '';
@@ -106,6 +112,9 @@ export interface LiquidTag extends ASTNode<NodeTypes.LiquidTag> {
   blockStartPosition: Position;
   blockEndPosition?: Position;
 }
+
+export interface LiquidTagEcho extends LiquidTagNode<'echo', LiquidVariable> {}
+export interface LiquidTagBaseCase extends LiquidTagNode<string, string> {}
 
 export interface LiquidBranch extends ASTNode<NodeTypes.LiquidBranch> {
   /**
@@ -262,7 +271,8 @@ export function isBranchedTag(node: LiquidHtmlNode) {
 }
 
 // Not exported because you can use node.type === NodeTypes.LiquidBranch.
-function isBranchTag(node: LiquidHtmlNode) {
+// TODO signature is a hack.
+function isBranchTag(node: LiquidHtmlNode): node is LiquidTagBaseCase {
   return (
     node.type === NodeTypes.LiquidTag &&
     ['else', 'elsif', 'when'].includes(node.name)
@@ -456,16 +466,7 @@ export function cstToAst(
       }
 
       case ConcreteNodeTypes.LiquidTag: {
-        builder.push({
-          type: NodeTypes.LiquidTag,
-          markup: node.markup,
-          position: position(node),
-          name: node.name,
-          whitespaceStart: node.whitespaceStart ?? '',
-          whitespaceEnd: node.whitespaceEnd ?? '',
-          blockStartPosition: position(node),
-          source,
-        });
+        builder.push(toLiquidTag(node, source));
         break;
       }
 
@@ -642,6 +643,49 @@ function toAttributes(
 function toName(name: string | ConcreteLiquidDrop, source: string) {
   if (typeof name === 'string') return name;
   return toLiquidDrop(name, source);
+}
+
+function liquidTagBaseAttributes(
+  node: ConcreteLiquidTag,
+  source: string,
+): Omit<LiquidTag, 'name' | 'markup'> {
+  return {
+    type: NodeTypes.LiquidTag,
+    position: position(node),
+    whitespaceStart: node.whitespaceStart ?? '',
+    whitespaceEnd: node.whitespaceEnd ?? '',
+    blockStartPosition: position(node),
+    source,
+  };
+}
+
+function toLiquidTag(node: ConcreteLiquidTag, source: string): LiquidTag {
+  if (typeof node.markup !== 'string') {
+    return toNamedLiquidTag(node as ConcreteLiquidTagNamed, source);
+  }
+  return {
+    name: node.name,
+    markup: node.markup,
+    ...liquidTagBaseAttributes(node, source),
+  };
+}
+
+function toNamedLiquidTag(
+  node: ConcreteLiquidTagNamed,
+  source: string,
+): LiquidTagNamed {
+  switch (node.name) {
+    case 'echo': {
+      return {
+        name: 'echo',
+        markup: toLiquidVariable(node.markup, source),
+        ...liquidTagBaseAttributes(node, source),
+      };
+    }
+    // default: {
+    //   return assertNever(node);
+    // }
+  }
 }
 
 function toLiquidDrop(node: ConcreteLiquidDrop, source: string): LiquidDrop {

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -439,6 +439,35 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
         expectLocation(cst, '0.markup');
       });
     });
+
+    it('should parse the assign tag as assign markup + liquid variable', () => {
+      [
+        {
+          expression: `x = "hi"`,
+          name: 'x',
+          expressionType: 'String',
+          expressionValue: 'hi',
+          filters: [],
+        },
+        { expression: `z = y | f`, name: 'z', expressionType: 'VariableLookup', filters: ['f'] },
+      ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
+        cst = toLiquidHtmlCST(`{% assign ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTag');
+        expectPath(cst, '0.name').to.equal('assign');
+        debugger;
+        expectPath(cst, '0.markup.type').to.equal('AssignMarkup');
+        expectPath(cst, '0.markup.name').to.equal(name);
+        expectPath(cst, '0.markup.value.expression.type').to.equal(expressionType);
+        if (expressionValue) {
+          expectPath(cst, '0.markup.value.expression.value').to.equal(expressionValue);
+        }
+        expectPath(cst, '0.markup.value.filters').to.have.lengthOf(filters.length);
+        expectPath(cst, '0.whitespaceStart').to.equal(null);
+        expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        expectLocation(cst, '0');
+        expectLocation(cst, '0.markup');
+      });
+    });
   });
 
   describe('Case: LiquidNode', () => {
@@ -470,9 +499,9 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
     });
 
     it('should basically parse liquid tags', () => {
-      cst = toLiquidHtmlCST('{%   assign x = 1 %}{% if hi -%}{%- endif %}');
+      cst = toLiquidHtmlCST('{%   unknown x = 1 %}{% if hi -%}{%- endif %}');
       expectPath(cst, '0.type').to.equal('LiquidTag');
-      expectPath(cst, '0.name').to.equal('assign');
+      expectPath(cst, '0.name').to.equal('unknown');
       expectPath(cst, '0.markup').to.equal('x = 1');
       expectPath(cst, '0.whitespaceStart').to.equal(null);
       expectPath(cst, '0.whitespaceEnd').to.equal(null);

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -418,6 +418,29 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
     });
   });
 
+  describe('Case: LiquidTag', () => {
+    it('should parse the echo tag as variables', () => {
+      [
+        { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
+        { expression: `x | f`, expressionType: 'VariableLookup', filters: ['f'] },
+      ].forEach(({ expression, expressionType, expressionValue, filters }) => {
+        cst = toLiquidHtmlCST(`{% echo ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTag');
+        expectPath(cst, '0.name').to.equal('echo');
+        expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+        expectPath(cst, '0.markup.expression.type').to.equal(expressionType);
+        if (expressionValue) {
+          expectPath(cst, '0.markup.expression.value').to.equal(expressionValue);
+        }
+        expectPath(cst, '0.markup.filters').to.have.lengthOf(filters.length);
+        expectPath(cst, '0.whitespaceStart').to.equal(null);
+        expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        expectLocation(cst, '0');
+        expectLocation(cst, '0.markup');
+      });
+    });
+  });
+
   describe('Case: LiquidNode', () => {
     it('should parse raw tags', () => {
       ['style', 'raw'].forEach((raw) => {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -376,7 +376,9 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locEnd,
     },
 
-    liquidTag: {
+    liquidTag: 0,
+    liquidTagBaseCase: 0,
+    liquidTagRule: {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
       markup: markup(5),

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -140,11 +140,21 @@ export interface ConcreteLiquidTagClose
   name: string;
 }
 
-export interface ConcreteLiquidTag
+export type ConcreteLiquidTag =
+  | ConcreteLiquidTagNamed
+  | ConcreteLiquidTagBaseCase;
+export type ConcreteLiquidTagNamed = ConcreteLiquidTagEcho;
+
+export interface ConcreteLiquidTagNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
-  name: string;
-  markup: string;
+  name: Name;
+  markup: Markup;
 }
+
+export interface ConcreteLiquidTagBaseCase
+  extends ConcreteLiquidTagNode<string, string> {}
+export interface ConcreteLiquidTagEcho
+  extends ConcreteLiquidTagNode<'echo', ConcreteLiquidVariable> {}
 
 export interface ConcreteLiquidDrop
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidDrop> {
@@ -378,10 +388,19 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
 
     liquidTag: 0,
     liquidTagBaseCase: 0,
+    liquidTagEcho: 0,
+    liquidTagEchoMarkup: 0,
     liquidTagRule: {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
-      markup: markup(5),
+      markup(nodes: Node[]) {
+        const markupNode = nodes[5];
+        const nameNode = nodes[3];
+        if (nameNode.sourceString !== 'echo') {
+          return markupNode.sourceString.trim();
+        }
+        return markupNode.toAST((this as any).args.mapping);
+      },
       whitespaceStart: 1,
       whitespaceEnd: 6,
       locStart,

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -91,6 +91,7 @@ function getCssDisplay(
     case NodeTypes.Number:
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
+    case NodeTypes.AssignMarkup:
       return 'should not be relevant';
 
     default:
@@ -144,6 +145,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.Number:
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
+    case NodeTypes.AssignMarkup:
       return 'should not be relevant';
 
     default:

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -374,6 +374,10 @@ function printNode(
       ];
     }
 
+    case NodeTypes.AssignMarkup: {
+      return [node.name, ' = ', path.call(print, 'value')];
+    }
+
     case NodeTypes.LiquidVariable: {
       const name = path.call(print, 'expression');
       let filters: Doc = '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export enum NodeTypes {
   Number = 'Number',
   Range = 'Range',
   VariableLookup = 'VariableLookup',
+
+  AssignMarkup = 'AssignMarkup',
 }
 
 export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
@@ -157,6 +159,7 @@ export type LiquidNode = Augmented<AST.LiquidNode, AllAugmentations>;
 export type ParentNode = Augmented<AST.ParentNode, AllAugmentations>;
 export type LiquidRawTag = Augmented<AST.LiquidRawTag, AllAugmentations>;
 export type LiquidTag = Augmented<AST.LiquidTag, AllAugmentations>;
+export type LiquidTagNamed = Augmented<AST.LiquidTagNamed, AllAugmentations>;
 export type LiquidBranch = Augmented<AST.LiquidBranch, AllAugmentations>;
 export type LiquidDrop = Augmented<AST.LiquidDrop, AllAugmentations>;
 export type HtmlNode = Augmented<AST.HtmlNode, AllAugmentations>;

--- a/test/liquid-tag-assign/fixed.liquid
+++ b/test/liquid-tag-assign/fixed.liquid
@@ -1,0 +1,75 @@
+It should never break a name
+printWidth: 1
+{% assign z = x %}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{% assign z = x
+  | filter1
+  | filter2
+%}
+
+It should break and indent named arguments
+printWidth: 1
+{% assign z = x
+  | filter1:
+    key1: value1,
+    key2: value2
+  | filter2
+%}
+
+It should not break the first positional argument
+printWidth: 1
+{% assign z = x
+  | filter1: arg1
+  | filter2: arg2,
+    arg3,
+    arg4
+%}
+
+It should break arguments only if necessary
+printWidth: 40
+{% assign z = x
+  | filter1: key1: value1, key2: value2
+  | filter2
+%}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{% assign z = x
+  | filter1: pos1,
+    pos2,
+    key1: val1,
+    key2: val2
+%}
+
+It should support a mix of positional and named arguments as expected (p40)
+printWidth: 50
+{% assign z = x
+  | filter1: pos1, pos2, key1: val1, key2: val2
+%}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{% assign z = x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support all types of arguments
+{% assign z = x | f: 'string' %}
+{% assign z = x | f: 'string' %}
+{% assign z = x | f: 0.0 %}
+{% assign z = x | f: 0 %}
+{% assign z = x | f: x %}
+{% assign z = x | f: (0..a) %}
+{% assign z = x | f: true %}
+
+It should support all types of named arguments, and add spaces
+{% assign z = x | f: key: 'string' %}
+{% assign z = x | f: key: 'string' %}
+{% assign z = x | f: key: 0.0 %}
+{% assign z = x | f: key: 0 %}
+{% assign z = x | f: key: x %}
+{% assign z = x | f: key: (0..a) %}
+{% assign z = x | f: key: true %}
+
+It should support spaces or lack of thereof erywhere
+{% assign z = x | f: a: b, range: (a..b) %}

--- a/test/liquid-tag-assign/index.liquid
+++ b/test/liquid-tag-assign/index.liquid
@@ -1,0 +1,55 @@
+It should never break a name
+printWidth: 1
+{% assign z = x %}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{% assign z = x | filter1 | filter2 %}
+
+It should break and indent named arguments
+printWidth: 1
+{% assign z = x | filter1: key1: value1, key2: value2 | filter2 %}
+
+It should not break the first positional argument
+printWidth: 1
+{% assign z = x | filter1: arg1 | filter2: arg2, arg3, arg4 %}
+
+It should break arguments only if necessary
+printWidth: 40
+{% assign z = x | filter1: key1: value1, key2: value2 | filter2 %}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{% assign z = x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support a mix of positional and named arguments as expected (p50)
+printWidth: 50
+{% assign z = x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{% assign z = x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support all types of arguments, and add spaces
+{% assign z=x|f:'string' %}
+{% assign z=x|f:"string" %}
+{% assign z=x|f:0.0 %}
+{% assign z=x|f:0 %}
+{% assign z=x|f:x %}
+{% assign z=x|f:(0..a) %}
+{% assign z=x|f:true %}
+
+It should support all types of named arguments, and add spaces
+{% assign z=x|f:key:'string' %}
+{% assign z=x|f:key:"string" %}
+{% assign z=x|f:key:0.0 %}
+{% assign z=x|f:key:0 %}
+{% assign z=x|f:key:x %}
+{% assign z=x|f:key:(0..a) %}
+{% assign z=x|f:key:true %}
+
+It should support spaces or lack of thereof erywhere
+{% assign z =   x|f:
+a    :  b  , range
+: ( a .. b)
+%}

--- a/test/liquid-tag-assign/index.spec.ts
+++ b/test/liquid-tag-assign/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-echo/fixed.liquid
+++ b/test/liquid-tag-echo/fixed.liquid
@@ -1,0 +1,75 @@
+It should never break a name
+printWidth: 1
+{% echo x %}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{% echo x
+  | filter1
+  | filter2
+%}
+
+It should break and indent named arguments
+printWidth: 1
+{% echo x
+  | filter1:
+    key1: value1,
+    key2: value2
+  | filter2
+%}
+
+It should not break the first positional argument
+printWidth: 1
+{% echo x
+  | filter1: arg1
+  | filter2: arg2,
+    arg3,
+    arg4
+%}
+
+It should break arguments only if necessary
+printWidth: 40
+{% echo x
+  | filter1: key1: value1, key2: value2
+  | filter2
+%}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{% echo x
+  | filter1: pos1,
+    pos2,
+    key1: val1,
+    key2: val2
+%}
+
+It should support a mix of positional and named arguments as expected (p40)
+printWidth: 50
+{% echo x
+  | filter1: pos1, pos2, key1: val1, key2: val2
+%}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{% echo x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support all types of arguments
+{% echo x | f: 'string' %}
+{% echo x | f: 'string' %}
+{% echo x | f: 0.0 %}
+{% echo x | f: 0 %}
+{% echo x | f: x %}
+{% echo x | f: (0..a) %}
+{% echo x | f: true %}
+
+It should support all types of named arguments, and add spaces
+{% echo x | f: key: 'string' %}
+{% echo x | f: key: 'string' %}
+{% echo x | f: key: 0.0 %}
+{% echo x | f: key: 0 %}
+{% echo x | f: key: x %}
+{% echo x | f: key: (0..a) %}
+{% echo x | f: key: true %}
+
+It should support spaces or lack of thereof erywhere
+{% echo x | f: a: b, range: (a..b) %}

--- a/test/liquid-tag-echo/index.liquid
+++ b/test/liquid-tag-echo/index.liquid
@@ -1,0 +1,55 @@
+It should never break a name
+printWidth: 1
+{% echo x %}
+
+It should break before/after delimiters and indent everything
+printWidth: 1
+{% echo x | filter1 | filter2 %}
+
+It should break and indent named arguments
+printWidth: 1
+{% echo x | filter1: key1: value1, key2: value2 | filter2 %}
+
+It should not break the first positional argument
+printWidth: 1
+{% echo x | filter1: arg1 | filter2: arg2, arg3, arg4 %}
+
+It should break arguments only if necessary
+printWidth: 40
+{% echo x | filter1: key1: value1, key2: value2 | filter2 %}
+
+It should support a mix of positional and named arguments as expected (p1)
+printWidth: 1
+{% echo x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support a mix of positional and named arguments as expected (p50)
+printWidth: 50
+{% echo x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support a mix of positional and named arguments as expected (p80)
+printWidth: 80
+{% echo x | filter1: pos1, pos2, key1: val1, key2: val2 %}
+
+It should support all types of arguments, and add spaces
+{% echo x|f:'string' %}
+{% echo x|f:"string" %}
+{% echo x|f:0.0 %}
+{% echo x|f:0 %}
+{% echo x|f:x %}
+{% echo x|f:(0..a) %}
+{% echo x|f:true %}
+
+It should support all types of named arguments, and add spaces
+{% echo x|f:key:'string' %}
+{% echo x|f:key:"string" %}
+{% echo x|f:key:0.0 %}
+{% echo x|f:key:0 %}
+{% echo x|f:key:x %}
+{% echo x|f:key:(0..a) %}
+{% echo x|f:key:true %}
+
+It should support spaces or lack of thereof erywhere
+{% echo   x|f:
+a    :  b  , range
+: ( a .. b)
+%}

--- a/test/liquid-tag-echo/index.spec.ts
+++ b/test/liquid-tag-echo/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/whitespace-trim-on-liquid-tag-break/fixed.liquid
+++ b/test/whitespace-trim-on-liquid-tag-break/fixed.liquid
@@ -1,7 +1,3 @@
-|print-width--------------------------------------------------------------------|
-
-In children array,
-
 it should not add Whitespace Trim Characters (WTC) if the liquid tag does not
 break on a new line
 <div>{% echo 'hello' %}</div>
@@ -23,10 +19,6 @@ previous/next characters were spaces
 <div>
   {% echo 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' %}
 </div>
-
---------------------------------------------------------------------------------
-
-In paragraphs,
 
 it should break next to a character, so there should be wtc
 <div>

--- a/test/whitespace-trim-on-liquid-tag-break/index.liquid
+++ b/test/whitespace-trim-on-liquid-tag-break/index.liquid
@@ -1,7 +1,3 @@
-|print-width--------------------------------------------------------------------|
-
-In children array,
-
 it should not add Whitespace Trim Characters (WTC) if the liquid tag does not
 break on a new line
 <div>{% echo 'hello' %}</div>
@@ -17,10 +13,6 @@ sensitive
 it should not add wtc if the liquid tag breaks on a new line and the
 previous/next characters were spaces
 <div> {% echo 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' %} </div>
-
---------------------------------------------------------------------------------
-
-In paragraphs,
 
 it should break next to a character, so there should be wtc
 <div>


### PR DESCRIPTION
### In this PR:

- Minor refactor of liquidTag ohm rule to be open for extension
- Add pretty printing of the `echo` liquid tag
- Add pretty printing of the `assign` tag

### Decisions

- `echo` tag
    - print tag name and variable expression on the same line as the opening `{%`
    - break and indent filters (if necessary)
    - `%}` on an empty line (if breaking)
- `assign` tag
    - print tag name, variable name, '=', and variable expression on the same line as the opening `{%`
    - break and indent filters (if necessary)
    - `%}` on an empty line (if breaking)
    - [example from Dawn](https://github.com/Shopify/dawn/compare/wip%2Fprettier...Shopify:wip%2Fprettier-2#diff-f38ed67a42b1f5bee67cf7ed5873cf1839d3e83f21848da0c327078dffe47de0R616-R618)
    
#### Rationale:

As per #13 and #23, it looks like we want indented args. Also It looks like we want tags to behave differently from drops, as tags always have a name. So I opted for going `{% $tagName $tagFirstArg` on the first line, because they usually all go together. For assign, I opted for also putting the `= $expression` on the first line, so that it behaves like echo. 

Moreover, you could swap a `{% echo x %}` for `{% assign z = x %}` without having to reindent the body. The Liquid drop is close, but would require the `x` on a new line, indented. 

```liquid
Those two are similar and are indented the same. 
{% assign z = x
  | filter1:
    key1: value1,
    key2: value2
  | filter2
%}

{% echo x
  | filter1:
    key1: value1,
    key2: value2
  | filter2
%}

{{ 
  x
  | filter1:
    key1: value1,
    key2: value2
  | filter2
}}
```


### Examples from tests

```liquid
It should break and indent named arguments
printWidth: 1
{% assign z = x
  | filter1:
    key1: value1,
    key2: value2
  | filter2
%}

It should break and indent named arguments
printWidth: 1
{% echo x
  | filter1:
    key1: value1,
    key2: value2
  | filter2
%}
```

Fixes #50 

[Demo on Dawn of diff with v0.2.0](https://github.com/Shopify/dawn/compare/wip%2Fprettier...Shopify:wip%2Fprettier-2)