### PR TITLE
Add proper support for `section` tag

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -82,6 +82,7 @@ LiquidHTML {
     | liquidTagAssign
     | liquidTagRender
     | liquidTagInclude
+    | liquidTagSection
     | liquidTagBaseCase
 
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
@@ -92,6 +93,9 @@ LiquidHTML {
 
   liquidTagAssign = liquidTagRule<"assign", liquidTagAssignMarkup>
   liquidTagAssignMarkup = variableSegment space* "=" space* liquidVariable
+
+  liquidTagSection = liquidTagRule<"section", liquidTagSectionMarkup>
+  liquidTagSectionMarkup = liquidString space*
 
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -102,7 +102,8 @@ export type LiquidTagNamed =
   | LiquidTagAssign
   | LiquidTagEcho
   | LiquidTagInclude
-  | LiquidTagRender;
+  | LiquidTagRender
+  | LiquidTagSection;
 
 export interface LiquidTagNode<Name, Markup>
   extends ASTNode<NodeTypes.LiquidTag> {
@@ -124,8 +125,8 @@ export interface LiquidTagNode<Name, Markup>
   blockEndPosition?: Position;
 }
 
-export interface LiquidTagEcho extends LiquidTagNode<'echo', LiquidVariable> {}
 export interface LiquidTagBaseCase extends LiquidTagNode<string, string> {}
+export interface LiquidTagEcho extends LiquidTagNode<'echo', LiquidVariable> {}
 
 export interface LiquidTagAssign
   extends LiquidTagNode<'assign', AssignMarkup> {}
@@ -137,6 +138,9 @@ export interface LiquidTagRender
   extends LiquidTagNode<'render', RenderMarkup> {}
 export interface LiquidTagInclude
   extends LiquidTagNode<'include', RenderMarkup> {}
+
+export interface LiquidTagSection
+  extends LiquidTagNode<'section', LiquidString> {}
 
 export interface RenderMarkup extends ASTNode<NodeTypes.RenderMarkup> {
   snippet: LiquidString | LiquidVariableLookup;
@@ -729,6 +733,13 @@ function toNamedLiquidTag(
       return {
         name: node.name,
         markup: toRenderMarkup(node.markup, source),
+        ...liquidTagBaseAttributes(node, source),
+      };
+    }
+    case 'section': {
+      return {
+        name: node.name,
+        markup: toExpression(node.markup, source) as LiquidString,
         ...liquidTagBaseAttributes(node, source),
       };
     }

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -150,8 +150,9 @@ export type ConcreteLiquidTag =
 export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagAssign
   | ConcreteLiquidTagEcho
+  | ConcreteLiquidTagInclude
   | ConcreteLiquidTagRender
-  | ConcreteLiquidTagInclude;
+  | ConcreteLiquidTagSection;
 
 export interface ConcreteLiquidTagNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
@@ -163,6 +164,8 @@ export interface ConcreteLiquidTagBaseCase
   extends ConcreteLiquidTagNode<string, string> {}
 export interface ConcreteLiquidTagEcho
   extends ConcreteLiquidTagNode<'echo', ConcreteLiquidVariable> {}
+export interface ConcreteLiquidTagSection
+  extends ConcreteLiquidTagNode<'section', ConcreteStringLiteral> {}
 
 export interface ConcreteLiquidTagAssign
   extends ConcreteLiquidTagNode<'assign', ConcreteLiquidTagAssignMarkup> {}
@@ -427,6 +430,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     liquidTagAssign: 0,
     liquidTagRender: 0,
     liquidTagInclude: 0,
+    liquidTagSection: 0,
     liquidTagRule: {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
@@ -434,7 +438,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
         const markupNode = nodes[5];
         const nameNode = nodes[3];
         if (
-          ['echo', 'assign', 'render', 'include'].includes(
+          ['echo', 'assign', 'render', 'include', 'section'].includes(
             nameNode.sourceString,
           )
         ) {
@@ -448,6 +452,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locEnd,
     },
     liquidTagEchoMarkup: 0,
+    liquidTagSectionMarkup: 0,
     liquidTagAssignMarkup: {
       type: ConcreteNodeTypes.AssignMarkup,
       name: 0,
@@ -455,6 +460,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locStart,
       locEnd,
     },
+
     liquidTagRenderMarkup: {
       type: ConcreteNodeTypes.RenderMarkup,
       snippet: 0,

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -97,35 +97,28 @@ function printNamedLiquidBlock(
 ): Doc {
   const node = path.getValue();
 
+  const tag = (whitespace: Doc) =>
+    group([
+      '{%',
+      whitespaceStart,
+      ' ',
+      node.name,
+      ' ',
+      indent(path.call((p) => print(p), 'markup')),
+      whitespace,
+      whitespaceEnd,
+      '%}',
+    ]);
+
   switch (node.name) {
     case 'echo': {
       const whitespace = node.markup.filters.length > 0 ? line : ' ';
-      return group([
-        '{%',
-        whitespaceStart,
-        ' ',
-        'echo',
-        ' ',
-        indent(path.call((p) => print(p), 'markup')),
-        whitespace,
-        whitespaceEnd,
-        '%}',
-      ]);
+      return tag(whitespace);
     }
 
     case 'assign': {
       const whitespace = node.markup.value.filters.length > 0 ? line : ' ';
-      return group([
-        '{%',
-        whitespaceStart,
-        ' ',
-        node.name,
-        ' ',
-        indent(path.call((p) => print(p), 'markup')),
-        whitespace,
-        whitespaceEnd,
-        '%}',
-      ]);
+      return tag(whitespace);
     }
 
     case 'include':
@@ -135,17 +128,11 @@ function printNamedLiquidBlock(
         markup.args.length > 0 || (markup.variable && markup.alias)
           ? line
           : ' ';
-      return group([
-        '{%',
-        whitespaceStart,
-        ' ',
-        node.name,
-        ' ',
-        indent(path.call((p) => print(p), 'markup')),
-        whitespace,
-        whitespaceEnd,
-        '%}',
-      ]);
+      return tag(whitespace);
+    }
+
+    case 'section': {
+      return tag(' ');
     }
 
     default: {

--- a/test/liquid-tag-section/fixed.liquid
+++ b/test/liquid-tag-section/fixed.liquid
@@ -1,0 +1,6 @@
+It should never break a name
+printWidth: 1
+{% section 'sectionName' %}
+{% section 'sectionName' %}
+{% section 'sectionName' %}
+{%- section 'sectionName' -%}

--- a/test/liquid-tag-section/index.liquid
+++ b/test/liquid-tag-section/index.liquid
@@ -1,0 +1,8 @@
+It should never break a name
+printWidth: 1
+{% section  "sectionName"  %}
+{% section "sectionName" %}
+{%section "sectionName"%}
+{%- section
+"sectionName"
+-%}

--- a/test/liquid-tag-section/index.spec.ts
+++ b/test/liquid-tag-section/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Print section tag as `{% section $string %}`
- Strips superfluous whitespace
- Adds missing whitespace
- Respects liquidSingleQuote

Fixes #59
