### PR TITLE
Add support for `form` liquid tags

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -75,8 +75,9 @@ LiquidHTML {
   LiquidNode = liquidNode
   liquidNode = liquidRawTag | liquidDrop | liquidTagClose | liquidTagOpen | liquidTag | liquidInlineComment
 
-  liquidTagOpen = liquidTagOpenBaseCase
-  liquidTagOpenBaseCase = liquidTagOpenRule<blockName, tagMarkup>
+  liquidTagOpen =
+    | liquidTagOpenForm
+    | liquidTagOpenBaseCase
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
     | liquidTagEcho
@@ -111,6 +112,11 @@ LiquidHTML {
   renderVariableExpression = space+ ("for" | "with") space+ liquidExpression
   renderAliasExpression = space+ "as" space+ variableSegment
   renderArguments = listOf<namedArgument, argumentSeparatorOptionalComma>
+
+  liquidTagOpenBaseCase = liquidTagOpenRule<blockName, tagMarkup>
+
+  liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
+  liquidTagOpenFormMarkup = arguments space*
 
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -173,14 +173,14 @@ LiquidHTML {
   indexLookup = space* "[" space* liquidExpression space* "]"
   dotLookup = space* "." space* identifier
 
-  liquidFilter = space* "|" space* identifier (space* ":" space* filterArguments)?
-  filterArguments = listOf<filterArgument, argumentSeparator>
-  filterArgument = namedArgument | positionalArgument
-  positionalArgument = liquidExpression
-  namedArgument = variableSegment space* ":" space* liquidExpression
+  liquidFilter = space* "|" space* identifier (space* ":" space* arguments)?
 
+  arguments = nonemptyOrderedListOf<positionalArgument, namedArgument, argumentSeparator>
   argumentSeparator = space* "," space*
   argumentSeparatorOptionalComma = space* ","? space*
+  positionalArgument = liquidExpression ~(space* ":")
+  namedArgument = variableSegment space* ":" space* liquidExpression
+
   variableSegment = (letter | "_") identifierCharacter*
   variableSegmentAsLookup = variableSegment
   identifier = variableSegment "?"?
@@ -230,6 +230,16 @@ LiquidHTML {
   AnyExceptPlus<lit> = (~ lit any)+
   AnyExceptStar<lit> = (~ lit any)*
   identifierCharacter = alnum | "_" | "-"
+
+  orderedListOf<a, b, sep> =
+    | nonemptyOrderedListOf<a, b, sep>
+    | emptyListOf<a, sep>
+  nonemptyOrderedListOf<a, b, sep> =
+    | nonemptyListOf<b, sep>
+    | nonemptyOrderedListOfBoth<a, b, sep>
+    | nonemptyListOf<a, sep>
+  nonemptyOrderedListOfBoth<a, b, sep> =
+    nonemptyListOf<a, sep> (sep nonemptyListOf<b, sep>)
 
   TextNode = AnyExceptPlus<openControl>
   openControl = "<" | "{{" | "{%"

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -75,7 +75,8 @@ LiquidHTML {
   LiquidNode = liquidNode
   liquidNode = liquidRawTag | liquidDrop | liquidTagClose | liquidTagOpen | liquidTag | liquidInlineComment
 
-  liquidTagOpen = "{%" "-"? space* blockName space* tagMarkup "-"? "%}"
+  liquidTagOpen = liquidTagOpenBaseCase
+  liquidTagOpenBaseCase = liquidTagOpenRule<blockName, tagMarkup>
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
     | liquidTagEcho
@@ -85,8 +86,13 @@ LiquidHTML {
     | liquidTagSection
     | liquidTagBaseCase
 
+  // These two are the same but transformed differently
+  liquidTagRule<name, markup> =
+    "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
+  liquidTagOpenRule<name, markup> =
+    "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
+
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
-  liquidTagRule<name, markup> = "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
 
   liquidTagEcho = liquidTagRule<"echo", liquidTagEchoMarkup>
   liquidTagEchoMarkup = liquidVariable

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -25,10 +25,10 @@ import {
   ConcreteLiquidTagRenderMarkup,
   ConcreteRenderVariableExpression,
 } from '~/parser/cst';
-import { isLiquidHtmlNode, NodeTypes, Position } from '~/types';
+import { isLiquidHtmlNode, NamedTags, NodeTypes, Position } from '~/types';
 import { assertNever, deepGet, dropLast } from '~/utils';
 import { LiquidHTMLASTParsingError } from '~/parser/errors';
-import { TAGS_WITHOUT_MARKUP } from './grammar';
+import { TAGS_WITHOUT_MARKUP } from '~/parser/grammar';
 
 interface HasPosition {
   locStart: number;
@@ -126,21 +126,22 @@ export interface LiquidTagNode<Name, Markup>
 }
 
 export interface LiquidTagBaseCase extends LiquidTagNode<string, string> {}
-export interface LiquidTagEcho extends LiquidTagNode<'echo', LiquidVariable> {}
+export interface LiquidTagEcho
+  extends LiquidTagNode<NamedTags.echo, LiquidVariable> {}
 
 export interface LiquidTagAssign
-  extends LiquidTagNode<'assign', AssignMarkup> {}
+  extends LiquidTagNode<NamedTags.assign, AssignMarkup> {}
 export interface AssignMarkup extends ASTNode<NodeTypes.AssignMarkup> {
   name: string;
   value: LiquidVariable;
 }
 export interface LiquidTagRender
-  extends LiquidTagNode<'render', RenderMarkup> {}
+  extends LiquidTagNode<NamedTags.render, RenderMarkup> {}
 export interface LiquidTagInclude
-  extends LiquidTagNode<'include', RenderMarkup> {}
+  extends LiquidTagNode<NamedTags.include, RenderMarkup> {}
 
 export interface LiquidTagSection
-  extends LiquidTagNode<'section', LiquidString> {}
+  extends LiquidTagNode<NamedTags.section, LiquidString> {}
 
 export interface RenderMarkup extends ASTNode<NodeTypes.RenderMarkup> {
   snippet: LiquidString | LiquidVariableLookup;
@@ -714,29 +715,29 @@ function toNamedLiquidTag(
   source: string,
 ): LiquidTagNamed {
   switch (node.name) {
-    case 'echo': {
+    case NamedTags.echo: {
       return {
-        name: 'echo',
+        name: NamedTags.echo,
         markup: toLiquidVariable(node.markup, source),
         ...liquidTagBaseAttributes(node, source),
       };
     }
-    case 'assign': {
+    case NamedTags.assign: {
       return {
-        name: 'assign',
+        name: NamedTags.assign,
         markup: toAssignMarkup(node.markup, source),
         ...liquidTagBaseAttributes(node, source),
       };
     }
-    case 'include':
-    case 'render': {
+    case NamedTags.include:
+    case NamedTags.render: {
       return {
         name: node.name,
         markup: toRenderMarkup(node.markup, source),
         ...liquidTagBaseAttributes(node, source),
       };
     }
-    case 'section': {
+    case NamedTags.section: {
       return {
         name: node.name,
         markup: toExpression(node.markup, source) as LiquidString,

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -134,11 +134,22 @@ export interface ConcreteLiquidRawTag
   blockEndLocEnd: number;
 }
 
-export interface ConcreteLiquidTagOpen
+export type ConcreteLiquidTagOpen =
+  | ConcreteLiquidTagOpenBaseCase
+  | ConcreteLiquidTagOpenNamed;
+export type ConcreteLiquidTagOpenNamed = ConcreteLiquidTagOpenForm;
+
+export interface ConcreteLiquidTagOpenNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagOpen> {
-  name: string;
-  markup: string;
+  name: Name;
+  markup: Markup;
 }
+
+export interface ConcreteLiquidTagOpenBaseCase
+  extends ConcreteLiquidTagOpenNode<string, string> {}
+
+export interface ConcreteLiquidTagOpenForm
+  extends ConcreteLiquidTagOpenNode<NamedTags.form, ConcreteLiquidArgument[]> {}
 
 export interface ConcreteLiquidTagClose
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagClose> {
@@ -422,10 +433,10 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       name: 3,
       markup(nodes: Node[]) {
         const markupNode = nodes[5];
-        // const nameNode = nodes[3];
-        // if ([].includes(nameNode.sourceString)) {
-        //   return markupNode.toAST((this as any).args.mapping);
-        // }
+        const nameNode = nodes[3];
+        if (NamedTags.hasOwnProperty(nameNode.sourceString)) {
+          return markupNode.toAST((this as any).args.mapping);
+        }
         return markupNode.sourceString.trim();
       },
       whitespaceStart: 1,
@@ -433,6 +444,9 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locStart,
       locEnd,
     },
+
+    liquidTagOpenForm: 0,
+    liquidTagOpenFormMarkup: 0,
 
     liquidTagClose: {
       type: ConcreteNodeTypes.LiquidTagClose,

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -405,10 +405,19 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       blockEndLocEnd: (tokens: Node[]) => tokens[16].source.endIdx,
     },
 
-    liquidTagOpen: {
+    liquidTagOpen: 0,
+    liquidTagOpenBaseCase: 0,
+    liquidTagOpenRule: {
       type: ConcreteNodeTypes.LiquidTagOpen,
       name: 3,
-      markup: markup(5),
+      markup(nodes: Node[]) {
+        const markupNode = nodes[5];
+        // const nameNode = nodes[3];
+        // if ([].includes(nameNode.sourceString)) {
+        //   return markupNode.toAST((this as any).args.mapping);
+        // }
+        return markupNode.sourceString.trim();
+      },
       whitespaceStart: 1,
       whitespaceEnd: 6,
       locStart,

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -3,6 +3,7 @@ import { Node } from 'ohm-js';
 import { toAST } from 'ohm-js/extras';
 import { liquidHtmlGrammar } from '~/parser/grammar';
 import { LiquidHTMLCSTParsingError } from '~/parser/errors';
+import { NamedTags } from '~/types';
 
 export enum ConcreteNodeTypes {
   HtmlComment = 'HtmlComment',
@@ -163,12 +164,15 @@ export interface ConcreteLiquidTagNode<Name, Markup>
 export interface ConcreteLiquidTagBaseCase
   extends ConcreteLiquidTagNode<string, string> {}
 export interface ConcreteLiquidTagEcho
-  extends ConcreteLiquidTagNode<'echo', ConcreteLiquidVariable> {}
+  extends ConcreteLiquidTagNode<NamedTags.echo, ConcreteLiquidVariable> {}
 export interface ConcreteLiquidTagSection
-  extends ConcreteLiquidTagNode<'section', ConcreteStringLiteral> {}
+  extends ConcreteLiquidTagNode<NamedTags.section, ConcreteStringLiteral> {}
 
 export interface ConcreteLiquidTagAssign
-  extends ConcreteLiquidTagNode<'assign', ConcreteLiquidTagAssignMarkup> {}
+  extends ConcreteLiquidTagNode<
+    NamedTags.assign,
+    ConcreteLiquidTagAssignMarkup
+  > {}
 export interface ConcreteLiquidTagAssignMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.AssignMarkup> {
   name: string;
@@ -176,9 +180,15 @@ export interface ConcreteLiquidTagAssignMarkup
 }
 
 export interface ConcreteLiquidTagRender
-  extends ConcreteLiquidTagNode<'render', ConcreteLiquidTagRenderMarkup> {}
+  extends ConcreteLiquidTagNode<
+    NamedTags.render,
+    ConcreteLiquidTagRenderMarkup
+  > {}
 export interface ConcreteLiquidTagInclude
-  extends ConcreteLiquidTagNode<'include', ConcreteLiquidTagRenderMarkup> {}
+  extends ConcreteLiquidTagNode<
+    NamedTags.include,
+    ConcreteLiquidTagRenderMarkup
+  > {}
 
 export interface ConcreteLiquidTagRenderMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
@@ -446,11 +456,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       markup(nodes: Node[]) {
         const markupNode = nodes[5];
         const nameNode = nodes[3];
-        if (
-          ['echo', 'assign', 'render', 'include', 'section'].includes(
-            nameNode.sourceString,
-          )
-        ) {
+        if (NamedTags.hasOwnProperty(nameNode.sourceString)) {
           return markupNode.toAST((this as any).args.mapping);
         }
         return markupNode.sourceString.trim();

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -535,8 +535,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
         }
       },
     },
-    filterArguments: 0,
-    filterArgument: 0,
+    arguments: 0,
     positionalArgument: 0,
     namedArgument: {
       type: ConcreteNodeTypes.NamedArgument,
@@ -640,6 +639,19 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
           : [frontmatter.toAST(self.args.mapping)];
 
       return frontmatterNode.concat(nodes.toAST(self.args.mapping));
+    },
+
+    orderedListOf: 0,
+    nonemptyOrderedListOf: 0,
+    nonemptyOrderedListOfBoth(
+      nonemptyListOfA: Node,
+      _sep: Node,
+      nonemptyListOfB: Node,
+    ) {
+      const self = this as any;
+      return nonemptyListOfA
+        .toAST(self.args.mapping)
+        .concat(nonemptyListOfB.toAST(self.args.mapping));
     },
 
     // Missing from ohm-js default rules. Those turn listOf rules into arrays.

--- a/src/printer/preprocess/augment-with-whitespace-helpers.spec.ts
+++ b/src/printer/preprocess/augment-with-whitespace-helpers.spec.ts
@@ -151,7 +151,7 @@ describe('Module: augmentWithWhitespaceHelpers', () => {
       const firstChilds = [
         '{{ drop -}}',
         '{% if true %}world{% endif -%}',
-        '{% form %}...{% endform -%}',
+        '{% form "cart" %}...{% endform -%}',
         '{% assign x = true -%}',
       ];
       const secondChilds = [
@@ -201,7 +201,7 @@ describe('Module: augmentWithWhitespaceHelpers', () => {
         'hello world',
         '{{ drop }}',
         '{% if true %}world{% endif %}',
-        '{% form %}...{% endform %}',
+        '{% form "cart" %}...{% endform %}',
         '{% assign x = true %}',
       ];
 

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -8,6 +8,7 @@ import {
   LiquidPrinterArgs,
   LiquidTag,
   LiquidTagNamed,
+  NamedTags,
   NodeTypes,
 } from '~/types';
 import { isBranchedTag } from '~/parser/ast';
@@ -111,18 +112,18 @@ function printNamedLiquidBlock(
     ]);
 
   switch (node.name) {
-    case 'echo': {
+    case NamedTags.echo: {
       const whitespace = node.markup.filters.length > 0 ? line : ' ';
       return tag(whitespace);
     }
 
-    case 'assign': {
+    case NamedTags.assign: {
       const whitespace = node.markup.value.filters.length > 0 ? line : ' ';
       return tag(whitespace);
     }
 
-    case 'include':
-    case 'render': {
+    case NamedTags.include:
+    case NamedTags.render: {
       const markup = node.markup;
       const whitespace =
         markup.args.length > 0 || (markup.variable && markup.alias)
@@ -131,7 +132,7 @@ function printNamedLiquidBlock(
       return tag(whitespace);
     }
 
-    case 'section': {
+    case NamedTags.section: {
       return tag(' ');
     }
 

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -136,6 +136,27 @@ function printNamedLiquidBlock(
       return tag(' ');
     }
 
+    case NamedTags.form: {
+      const args = node.markup;
+      const whitespace = args.length > 1 ? line : ' ';
+      return group([
+        '{%',
+        whitespaceStart,
+        ' ',
+        node.name,
+        ' ',
+        indent([
+          join(
+            [',', line],
+            path.map((p) => print(p), 'markup'),
+          ),
+        ]),
+        whitespace,
+        whitespaceEnd,
+        '%}',
+      ]);
+    }
+
     default: {
       return assertNever(node);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,16 @@ export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
   );
 }
 
+// These are officially supported with special node types
+export enum NamedTags {
+  echo = 'echo',
+  section = 'section',
+  assign = 'assign',
+  render = 'render',
+  include = 'include',
+  form = 'form',
+}
+
 export const HtmlNodeTypes = [
   NodeTypes.HtmlElement,
   NodeTypes.HtmlRawNode,

--- a/test/leading-whitespace-inside-block/fixed.liquid
+++ b/test/leading-whitespace-inside-block/fixed.liquid
@@ -1,29 +1,29 @@
 When it doesn't break, it should conditionally omit the leading space
 
 It should omit the leading space if it is stripped anyway
-{% form -%}space{% endform %}
+{% form 'cart' -%}space{% endform %}
 
 It should not omit the leading space if there's leading whitespace and the tag
 is leading whitespace sensitive
 htmlWhitespaceSensitivity: "strict"
-{% form %} space{% endform %}
-{%- form %} space{% endform -%}
-{% form %} space{% endform %}
+{% form 'cart' %} space{% endform %}
+{%- form 'cart' %} space{% endform -%}
+{% form 'cart' %} space{% endform %}
 
 It should omit the leading space if there's leading whitespace and the tag is
 not leading whitespace sensitive
-{% form %}space{% endform %}
-{%- form %}space{% endform -%}
-{% form %}space{% endform %}
+{% form 'cart' %}space{% endform %}
+{%- form 'cart' %}space{% endform -%}
+{% form 'cart' %}space{% endform %}
 
 It should not omit the whitespace if it is included in a tag that creates an
 inline formatting context
 htmlWhitespaceSensitivity: "strict"
-<p>haha{% form %} space{% endform %}</p>
+<p>haha{% form 'cart' %} space{% endform %}</p>
 
 It should omit the whitespace if it is included in a tag that creates a block
 formatting context.
 <p>
   haha
-  {% form %}space{% endform %}
+  {% form 'cart' %}space{% endform %}
 </p>

--- a/test/leading-whitespace-inside-block/index.liquid
+++ b/test/leading-whitespace-inside-block/index.liquid
@@ -1,26 +1,26 @@
 When it doesn't break, it should conditionally omit the leading space
 
 It should omit the leading space if it is stripped anyway
-{% form -%} space{% endform %}
+{% form 'cart' -%} space{% endform %}
 
 It should not omit the leading space if there's leading whitespace and the
 tag is leading whitespace sensitive
 htmlWhitespaceSensitivity: "strict"
-{% form %} space{% endform %}
-{%- form %} space{% endform -%}
-{% form %} space{% endform %}
+{% form 'cart' %} space{% endform %}
+{%- form 'cart' %} space{% endform -%}
+{% form 'cart' %} space{% endform %}
 
 It should omit the leading space if there's leading whitespace and the
 tag is not leading whitespace sensitive
-{% form %} space{% endform %}
-{%- form %} space{% endform -%}
-{% form %} space{% endform %}
+{% form 'cart' %} space{% endform %}
+{%- form 'cart' %} space{% endform -%}
+{% form 'cart' %} space{% endform %}
 
 It should not omit the whitespace if it is included in a tag that creates an
 inline formatting context
 htmlWhitespaceSensitivity: "strict"
-<p>haha{% form %} space{% endform %}</p>
+<p>haha{% form 'cart' %} space{% endform %}</p>
 
 It should omit the whitespace if it is included in a tag that creates a block
 formatting context.
-<p>haha{% form %} space{% endform %}</p>
+<p>haha{% form 'cart' %} space{% endform %}</p>

--- a/test/liquid-tag-form/fixed.liquid
+++ b/test/liquid-tag-form/fixed.liquid
@@ -1,0 +1,45 @@
+It always takes at least one argument, but we don't break it
+printWidth: 1
+{% form x %}{% endform %}
+{% form x %}
+  hello
+{% endform %}
+
+It can take named arguments, and respects liquidSingleQuote
+printWidth: 1
+{% form 'cart',
+  key: value
+%}{% endform %}
+
+It can take named arguments, and respects liquidSingleQuote (pw80)
+printWidth: 80
+{% form 'cart', key1: value1, key2: 'value2' %}{% endform %}
+
+It can take positional arguments
+printWidth: 1
+{% form 'cart',
+  pos1
+%}{% endform %}
+{% form 'cart',
+  pos1,
+  pos2
+%}{% endform %}
+
+It can take positional and named arguments (at the same time)
+printWidth: 1
+{% form 'cart',
+  pos1[0],
+  empty,
+  key: true,
+  ind: (0..2)
+%}
+  <input type="submit">
+{% endform %}
+
+It indents content (without whitespace stripping b/c form is inner insensitive)
+printWidth: 1
+{% form 'cart',
+  pos1
+%}
+  hello
+{% endform %}

--- a/test/liquid-tag-form/index.liquid
+++ b/test/liquid-tag-form/index.liquid
@@ -1,0 +1,25 @@
+It always takes at least one argument, but we don't break it
+printWidth: 1
+{% form x %}{% endform %}
+{% form x %}hello{% endform %}
+
+It can take named arguments, and respects liquidSingleQuote
+printWidth: 1
+{% form "cart",key:value%}{% endform %}
+
+It can take named arguments, and respects liquidSingleQuote (pw80)
+printWidth: 80
+{% form "cart",key1:value1, key2:'value2' %} {% endform %}
+
+It can take positional arguments
+printWidth: 1
+{% form "cart",pos1%}{% endform %}
+{% form "cart",pos1,pos2%}{% endform %}
+
+It can take positional and named arguments (at the same time)
+printWidth: 1
+{% form "cart",pos1[0],empty,key:true,ind:(0..2)%}<input type="submit">{% endform %}
+
+It indents content (without whitespace stripping b/c form is inner insensitive)
+printWidth: 1
+{% form "cart",pos1%}hello{% endform %}

--- a/test/liquid-tag-form/index.spec.ts
+++ b/test/liquid-tag-form/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/trailing-whitespace-inside-block/fixed.liquid
+++ b/test/trailing-whitespace-inside-block/fixed.liquid
@@ -1,24 +1,24 @@
 When it doesn't break, it should conditionally omit the trailing space
 
 It should omit the trailing space if it is stripped anyway
-{% form %}space{%- endform %}
+{% form 'cart' %}space{%- endform %}
 
 It should not omit the trailing space if there's trailing whitespace and the
 parent is trailing space sensitive
-{% capture %}space {% endcapture %}
-{%- capture %}space {% endcapture -%}
-{% capture %}space {% endcapture %}
+{% capture var %}space {% endcapture %}
+{%- capture var %}space {% endcapture -%}
+{% capture var %}space {% endcapture %}
 
 It should omit the trailing space if there's trailing whitespace and the parent
 is not trailing space sensitive
-{% form %}space{% endform %}
-{%- form %}space{% endform -%}
-{% form %}space{% endform %}
+{% form 'cart' %}space{% endform %}
+{%- form 'cart' %}space{% endform -%}
+{% form 'cart' %}space{% endform %}
 
 It should not omit the whitespace because of whitespace stripping outside the
 tag
 <p>
-  {% capture %}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endcapture -%}
+  {% capture var %}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endcapture -%}
   {{- value }}
 </p>
 
@@ -26,6 +26,6 @@ It should omit the surrounding whitespace and inner whitespace for block
 rendering contexts
 <p>
   haha
-  {% form %}space{% endform %}
+  {% form 'cart' %}space{% endform %}
   haha
 </p>

--- a/test/trailing-whitespace-inside-block/index.liquid
+++ b/test/trailing-whitespace-inside-block/index.liquid
@@ -1,25 +1,25 @@
 When it doesn't break, it should conditionally omit the trailing space
 
 It should omit the trailing space if it is stripped anyway
-{% form %}space {%- endform %}
+{% form 'cart' %}space {%- endform %}
 
 It should not omit the trailing space if there's trailing whitespace and the
 parent is trailing space sensitive
-{% capture %}space {% endcapture %}
-{%- capture %}space {% endcapture -%}
-{% capture %}space {% endcapture %}
+{% capture var %}space {% endcapture %}
+{%- capture var %}space {% endcapture -%}
+{% capture var %}space {% endcapture %}
 
 It should omit the trailing space if there's trailing whitespace and the parent
 is not trailing space sensitive
-{% form %}space {% endform %}
-{%- form %}space {% endform -%}
-{% form %}space {% endform %}
+{% form 'cart' %}space {% endform %}
+{%- form 'cart' %}space {% endform -%}
+{% form 'cart' %}space {% endform %}
 
 It should not omit the whitespace because of whitespace stripping outside the tag
 <p>
-{% capture %}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endcapture %}{{ value }}
+{% capture var %}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endcapture %}{{ value }}
 </p>
 
 It should omit the surrounding whitespace and inner whitespace for block
 rendering contexts
-<p>haha{% form %}space {% endform %}haha</p>
+<p>haha{% form 'cart' %}space {% endform %}haha</p>

--- a/test/whitespace-trim-on-liquid-block-break/fixed.liquid
+++ b/test/whitespace-trim-on-liquid-block-break/fixed.liquid
@@ -37,7 +37,7 @@ In LiquidTag children array,
 If it breaks and the htmlWhitespaceSensitivity is 'strict', then add whitespace stripping
 htmlWhitespaceSensitivity: 'strict'
 printWidth: 30
-{% form -%}
+{% form 'cart' -%}
   aaaaaaaaaaaa
 {%- endform %}
 
@@ -51,13 +51,13 @@ printWidth: 30
 If it breaks and the node is display: inline add whitespace stripping
 printWidth: 30
 <!-- display: inline -->
-{% form -%}
+{% form 'cart' -%}
   aaaaaaaaaaaa
 {%- endform %}
 
 When it does break, there was a whitespace, and the parent is not
 leading/trailing space sensitive, it should not change anything
-{% form %}
+{% form 'cart' %}
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 {% endform %}
 

--- a/test/whitespace-trim-on-liquid-block-break/index.liquid
+++ b/test/whitespace-trim-on-liquid-block-break/index.liquid
@@ -22,7 +22,7 @@ In LiquidTag children array,
 If it breaks and the htmlWhitespaceSensitivity is 'strict', then add whitespace stripping
 htmlWhitespaceSensitivity: "strict"
 printWidth: 30
-{% form %}aaaaaaaaaaaa{% endform %}
+{% form 'cart' %}aaaaaaaaaaaa{% endform %}
 
 If it breaks and the htmlWhitespaceSensitivity is 'ignore', then omit whitespace stripping
 htmlWhitespaceSensitivity: "ignore"
@@ -32,11 +32,11 @@ printWidth: 30
 If it breaks and the node display is inline add whitespace stripping
 printWidth: 30
 <!-- display: inline -->
-{% form %}aaaaaaaaaaaa{% endform %}
+{% form 'cart' %}aaaaaaaaaaaa{% endform %}
 
 When it does break, there was a whitespace, and the parent is not
 leading/trailing space sensitive, it should not change anything
-{% form %} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endform %}
+{% form 'cart' %} aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {% endform %}
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Refactor liquidTagOpen rule to leave room for extension
- Convert tag names into an enum
- Make sure we have positional arguments before kwargs
- Add support for liquid `form` tags
