### PR TITLE
Add support for the `paginate` tag

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -77,6 +77,7 @@ LiquidHTML {
 
   liquidTagOpen =
     | liquidTagOpenForm
+    | liquidTagOpenPaginate
     | liquidTagOpenBaseCase
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
@@ -107,16 +108,19 @@ LiquidHTML {
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>
   liquidTagRenderMarkup =
-    snippetExpression renderVariableExpression? renderAliasExpression? (argumentSeparatorOptionalComma renderArguments) space*
+    snippetExpression renderVariableExpression? renderAliasExpression? (argumentSeparatorOptionalComma tagArguments) space*
   snippetExpression = liquidString | variableSegmentAsLookup
   renderVariableExpression = space+ ("for" | "with") space+ liquidExpression
   renderAliasExpression = space+ "as" space+ variableSegment
-  renderArguments = listOf<namedArgument, argumentSeparatorOptionalComma>
 
   liquidTagOpenBaseCase = liquidTagOpenRule<blockName, tagMarkup>
 
   liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
   liquidTagOpenFormMarkup = arguments space*
+
+  liquidTagOpenPaginate = liquidTagOpenRule<"paginate", liquidTagOpenPaginateMarkup>
+  liquidTagOpenPaginateMarkup =
+    liquidExpression space+ "by" space+ liquidExpression (argumentSeparatorOptionalComma tagArguments)? space*
 
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase
@@ -186,6 +190,7 @@ LiquidHTML {
   argumentSeparatorOptionalComma = space* ","? space*
   positionalArgument = liquidExpression ~(space* ":")
   namedArgument = variableSegment space* ":" space* liquidExpression
+  tagArguments = listOf<namedArgument, argumentSeparatorOptionalComma>
 
   variableSegment = (letter | "_") identifierCharacter*
   variableSegmentAsLookup = variableSegment

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -35,6 +35,7 @@ export enum ConcreteNodeTypes {
 
   AssignMarkup = 'AssignMarkup',
   RenderMarkup = 'RenderMarkup',
+  PaginateMarkup = 'PaginateMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
 }
 
@@ -137,7 +138,9 @@ export interface ConcreteLiquidRawTag
 export type ConcreteLiquidTagOpen =
   | ConcreteLiquidTagOpenBaseCase
   | ConcreteLiquidTagOpenNamed;
-export type ConcreteLiquidTagOpenNamed = ConcreteLiquidTagOpenForm;
+export type ConcreteLiquidTagOpenNamed =
+  | ConcreteLiquidTagOpenForm
+  | ConcreteLiquidTagOpenPaginate;
 
 export interface ConcreteLiquidTagOpenNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagOpen> {
@@ -150,6 +153,19 @@ export interface ConcreteLiquidTagOpenBaseCase
 
 export interface ConcreteLiquidTagOpenForm
   extends ConcreteLiquidTagOpenNode<NamedTags.form, ConcreteLiquidArgument[]> {}
+
+export interface ConcreteLiquidTagOpenPaginate
+  extends ConcreteLiquidTagOpenNode<
+    NamedTags.paginate,
+    ConcretePaginateMarkup
+  > {}
+
+export interface ConcretePaginateMarkup
+  extends ConcreteBasicNode<ConcreteNodeTypes.PaginateMarkup> {
+  collection: ConcreteLiquidExpression;
+  pageSize: ConcreteLiquidExpression;
+  args: ConcreteLiquidNamedArgument[] | null;
+}
 
 export interface ConcreteLiquidTagClose
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagClose> {
@@ -447,6 +463,15 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
 
     liquidTagOpenForm: 0,
     liquidTagOpenFormMarkup: 0,
+    liquidTagOpenPaginate: 0,
+    liquidTagOpenPaginateMarkup: {
+      type: ConcreteNodeTypes.PaginateMarkup,
+      collection: 0,
+      pageSize: 4,
+      args: 6,
+      locStart,
+      locEnd,
+    },
 
     liquidTagClose: {
       type: ConcreteNodeTypes.LiquidTagClose,
@@ -508,7 +533,6 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locEnd,
     },
     renderAliasExpression: 3,
-    renderArguments: 0,
 
     liquidDrop: {
       type: ConcreteNodeTypes.LiquidDrop,
@@ -550,6 +574,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       },
     },
     arguments: 0,
+    tagArguments: 0,
     positionalArgument: 0,
     namedArgument: {
       type: ConcreteNodeTypes.NamedArgument,

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -92,6 +92,7 @@ function getCssDisplay(
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
       return 'should not be relevant';
@@ -148,6 +149,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
       return 'should not be relevant';

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -157,6 +157,10 @@ function printNamedLiquidBlock(
       ]);
     }
 
+    case NamedTags.paginate: {
+      return tag(line);
+    }
+
     default: {
       return assertNever(node);
     }

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -382,6 +382,28 @@ function printNode(
       return [node.name, ' = ', path.call(print, 'value')];
     }
 
+    case NodeTypes.PaginateMarkup: {
+      const doc = [
+        path.call(print, 'collection'),
+        line,
+        'by ',
+        path.call(print, 'pageSize'),
+      ];
+
+      if (node.args.length > 0) {
+        doc.push([
+          ',',
+          line,
+          join(
+            [',', line],
+            path.map((p) => print(p), 'args'),
+          ),
+        ]);
+      }
+
+      return doc;
+    }
+
     case NodeTypes.RenderMarkup: {
       const snippet = path.call(print, 'snippet');
       const doc: Doc = [snippet];

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export enum NodeTypes {
   VariableLookup = 'VariableLookup',
 
   AssignMarkup = 'AssignMarkup',
+  PaginateMarkup = 'PaginateMarkup',
   RenderMarkup = 'RenderMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
 }
@@ -55,6 +56,7 @@ export enum NamedTags {
   render = 'render',
   include = 'include',
   form = 'form',
+  paginate = 'paginate',
 }
 
 export const HtmlNodeTypes = [

--- a/test/liquid-tag-paginate/fixed.liquid
+++ b/test/liquid-tag-paginate/fixed.liquid
@@ -1,0 +1,26 @@
+It takes a collection and a pageSize
+{% paginate collection by pageSize %}{% endpaginate %}
+
+It breaks on by pageSize when printWidth is hit
+printWidth: 1
+{% paginate collection
+  by pageSize
+%}
+  {{ collection }}
+{% endpaginate %}
+
+It is undocumented, but it also accepts named attributes (window_size). Those are comma separated.
+printWidth: 80
+{% paginate collection by pageSize, window_size: 50, attr: (0..2) %}
+  {{ collection }}
+{% endpaginate %}
+
+It is undocumented, but it also accepts named attributes (window_size). We print
+those comma separated and on a new line when it breaks.
+printWidth: 1
+{% paginate collection
+  by pageSize,
+  window_size: 50
+%}
+  {{ collection }}
+{% endpaginate %}

--- a/test/liquid-tag-paginate/index.liquid
+++ b/test/liquid-tag-paginate/index.liquid
@@ -1,0 +1,22 @@
+It takes a collection and a pageSize
+{% paginate collection by pageSize %}{% endpaginate %}
+
+It breaks on by pageSize when printWidth is hit
+printWidth: 1
+{% paginate collection by pageSize %}
+  {{ collection }}
+{% endpaginate %}
+
+It is undocumented, but it also accepts named attributes (window_size). Those are comma separated.
+printWidth: 80
+{% paginate collection by pageSize window_size:50, attr:(0.. 2) %}
+  {{ collection }}
+{% endpaginate %}
+
+It is undocumented, but it also accepts named attributes (window_size). We print
+those comma separated and on a new line when it breaks.
+printWidth: 1
+{% paginate collection by pageSize window_size: 50 %}
+  {{ collection }}
+{% endpaginate %}
+

--- a/test/liquid-tag-paginate/index.spec.ts
+++ b/test/liquid-tag-paginate/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Add support for the `paginate` liquid tag
- rename the ohm rule `renderArguments` -> `tagArguments`, because it starts to look like the comma-less pattern is repeated

## Decisions

- Echoing #75, `{% paginate $collection` on the first line
- MAYBE break `by $size` if really indented far
- MAYBE break `window_size: X` (undocumented feature) (and join with commas)
- `%}` on empty line if breaking

## Examples

```liquid
It takes a collection and a pageSize
{% paginate collection by pageSize %}{% endpaginate %}

It breaks on by pageSize when printWidth is hit
printWidth: 1
{% paginate collection
  by pageSize
%}
  {{ collection }}
{% endpaginate %}

It is undocumented, but it also accepts named attributes (window_size). Those are comma separated.
printWidth: 80
{% paginate collection by pageSize, window_size: 50, attr: (0..2) %}
  {{ collection }}
{% endpaginate %}

It is undocumented, but it also accepts named attributes (window_size). We print
those comma separated and on a new line when it breaks.
printWidth: 1
{% paginate collection
  by pageSize,
  window_size: 50
%}
  {{ collection }}
{% endpaginate %}
```

[Demo on dawn](https://github.com/Shopify/dawn/compare/wip%2Fprettier...Shopify:wip%2Fprettier-2)

Fixes #61
