### PR TITLE
Add support for `if`, `elsif` and `unless` tags

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -85,6 +85,7 @@ LiquidHTML {
   liquidTag =
     | liquidTagEcho
     | liquidTagAssign
+    | liquidTagElsif
     | liquidTagRender
     | liquidTagInclude
     | liquidTagSection
@@ -122,6 +123,8 @@ LiquidHTML {
 
   liquidTagOpenIf = liquidTagOpenRule<"if", liquidTagOpenConditionalMarkup>
   liquidTagOpenUnless = liquidTagOpenRule<"unless", liquidTagOpenConditionalMarkup>
+  liquidTagElsif = liquidTagRule<"elsif", liquidTagOpenConditionalMarkup>
+
   liquidTagOpenConditionalMarkup = nonemptyListOf<condition, conditionSeparator> space*
   conditionSeparator = &logicalOperator
   condition = logicalOperator? space* (comparison | liquidExpression) space*

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -176,7 +176,9 @@ LiquidHTML {
   liquidRange =
     "(" space* liquidExpression space* ".." space* liquidExpression space* ")"
 
-  liquidVariableLookup = variableSegment? lookup*
+  liquidVariableLookup =
+    | variableSegment lookup*
+    | empty lookup+
   lookup =
     | indexLookup
     | dotLookup
@@ -257,4 +259,5 @@ LiquidHTML {
   controls = "\u{007F}".."\u{009F}"
   noncharacters = "\u{FDD0}".."\u{FDEF}"
   newline = "\r"? "\n"
+  empty = /* nothing */
 }

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -77,6 +77,8 @@ LiquidHTML {
 
   liquidTagOpen =
     | liquidTagOpenForm
+    | liquidTagOpenIf
+    | liquidTagOpenUnless
     | liquidTagOpenPaginate
     | liquidTagOpenBaseCase
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
@@ -117,6 +119,22 @@ LiquidHTML {
 
   liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
   liquidTagOpenFormMarkup = arguments space*
+
+  liquidTagOpenIf = liquidTagOpenRule<"if", liquidTagOpenConditionalMarkup>
+  liquidTagOpenUnless = liquidTagOpenRule<"unless", liquidTagOpenConditionalMarkup>
+  liquidTagOpenConditionalMarkup = nonemptyListOf<condition, conditionSeparator> space*
+  conditionSeparator = &logicalOperator
+  condition = logicalOperator? space* (comparison | liquidExpression) space*
+  logicalOperator = ("and" | "or") ~identifier
+  comparison = liquidExpression space* comparator space* liquidExpression
+  comparator =
+    ( "=="
+    | "!="
+    | ">"
+    | "<"
+    | ">="
+    | "<=")
+    | ("contains" ~identifier)
 
   liquidTagOpenPaginate = liquidTagOpenRule<"paginate", liquidTagOpenPaginateMarkup>
   liquidTagOpenPaginateMarkup =

--- a/src/parser/ast.spec.ts
+++ b/src/parser/ast.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/ast';
-import { LiquidHTMLASTParsingError } from '~/parser/errors';
 import { deepGet } from '~/utils';
 
 describe('Unit: toLiquidHtmlAST', () => {
@@ -650,7 +649,7 @@ describe('Unit: toLiquidHtmlAST', () => {
 
     expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
     expectPath(ast, 'children.0.children.1.name').to.eql('elsif');
-    expectPath(ast, 'children.0.children.1.markup').to.eql('B');
+    expectPath(ast, 'children.0.children.1.markup.type').to.eql('VariableLookup');
     expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
     expectPath(ast, 'children.0.children.1.children.0.value').to.eql('B');
 

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -455,7 +455,6 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
         cst = toLiquidHtmlCST(`{% assign ${expression} -%}`);
         expectPath(cst, '0.type').to.equal('LiquidTag');
         expectPath(cst, '0.name').to.equal('assign');
-        debugger;
         expectPath(cst, '0.markup.type').to.equal('AssignMarkup');
         expectPath(cst, '0.markup.name').to.equal(name);
         expectPath(cst, '0.markup.value.expression.type').to.equal(expressionType);
@@ -622,8 +621,8 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
-    it('should parse the if and unless tag arguments as a list of conditions', () => {
-      ['if', 'unless'].forEach((tagName) => {
+    it('should parse the if, unless and elsif tag arguments as a list of conditions', () => {
+      ['if', 'unless', 'elsif'].forEach((tagName) => {
         [
           {
             expression: 'a',
@@ -654,7 +653,7 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
           },
         ].forEach(({ expression, conditions }) => {
           cst = toLiquidHtmlCST(`{% ${tagName} ${expression} -%}`);
-          expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+          expectPath(cst, '0.type').to.equal(tagName === 'elsif' ? 'LiquidTag' : 'LiquidTagOpen');
           expectPath(cst, '0.name').to.equal(tagName);
           expectPath(cst, '0.markup').to.have.lengthOf(conditions.length);
           conditions.forEach(({ relation, conditional }, i) => {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -704,6 +704,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     emptyListOf() {
       return [];
     },
+    empty: () => null,
   });
 
   return ohmAST as LiquidHtmlCST;

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -162,6 +162,8 @@ export interface ConcreteLiquidTagOpenUnless
     NamedTags.unless,
     ConcreteLiquidCondition[]
   > {}
+export interface ConcreteLiquidTagElsif
+  extends ConcreteLiquidTagNode<NamedTags.elsif, ConcreteLiquidCondition[]> {}
 
 export interface ConcreteLiquidCondition
   extends ConcreteBasicNode<ConcreteNodeTypes.Condition> {
@@ -203,14 +205,15 @@ export type ConcreteLiquidTag =
 export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagAssign
   | ConcreteLiquidTagEcho
+  | ConcreteLiquidTagElsif
   | ConcreteLiquidTagInclude
   | ConcreteLiquidTagRender
   | ConcreteLiquidTagSection;
 
 export interface ConcreteLiquidTagNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
-  name: Name;
   markup: Markup;
+  name: Name;
 }
 
 export interface ConcreteLiquidTagBaseCase
@@ -499,6 +502,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     },
     liquidTagOpenIf: 0,
     liquidTagOpenUnless: 0,
+    liquidTagElsif: 0,
     liquidTagOpenConditionalMarkup: 0,
     condition: {
       type: ConcreteNodeTypes.Condition,

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -95,6 +95,8 @@ function getCssDisplay(
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
+    case NodeTypes.LogicalExpression:
+    case NodeTypes.Comparison:
       return 'should not be relevant';
 
     default:
@@ -152,6 +154,8 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
+    case NodeTypes.LogicalExpression:
+    case NodeTypes.Comparison:
       return 'should not be relevant';
 
     default:

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -161,6 +161,17 @@ function printNamedLiquidBlock(
       return tag(line);
     }
 
+    case NamedTags.if:
+    case NamedTags.unless: {
+      const whitespace = [
+        NodeTypes.Comparison,
+        NodeTypes.LogicalExpression,
+      ].includes(node.markup.type)
+        ? line
+        : ' ';
+      return tag(whitespace);
+    }
+
     default: {
       return assertNever(node);
     }

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -8,6 +8,7 @@ import {
   LiquidPrinterArgs,
   LiquidTag,
   LiquidTagNamed,
+  LiquidBranchNamed,
   NamedTags,
   NodeTypes,
 } from '~/types';
@@ -90,7 +91,7 @@ export function printLiquidDrop(
 }
 
 function printNamedLiquidBlock(
-  path: AstPath<LiquidTagNamed>,
+  path: AstPath<LiquidTagNamed | LiquidBranchNamed>,
   _options: LiquidParserOptions,
   print: LiquidPrinter,
   whitespaceStart: Doc,
@@ -162,6 +163,7 @@ function printNamedLiquidBlock(
     }
 
     case NamedTags.if:
+    case NamedTags.elsif:
     case NamedTags.unless: {
       const whitespace = [
         NodeTypes.Comparison,
@@ -200,7 +202,7 @@ export function printLiquidBlockStart(
 
   if (typeof node.markup !== 'string') {
     return printNamedLiquidBlock(
-      path as AstPath<LiquidTagNamed>,
+      path as AstPath<LiquidTagNamed | LiquidBranchNamed>,
       options,
       print,
       whitespaceStart,

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -431,6 +431,23 @@ function printNode(
       return [node.kind, ' ', path.call(print, 'name')];
     }
 
+    case NodeTypes.LogicalExpression: {
+      return [
+        path.call(print, 'left'),
+        line,
+        node.relation,
+        ' ',
+        path.call(print, 'right'),
+      ];
+    }
+
+    case NodeTypes.Comparison: {
+      return group([
+        path.call(print, 'left'),
+        indent([line, node.comparator, ' ', path.call(print, 'right')]),
+      ]);
+    }
+
     case NodeTypes.LiquidVariable: {
       const name = path.call(print, 'expression');
       let filters: Doc = '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export enum NodeTypes {
   Number = 'Number',
   Range = 'Range',
   VariableLookup = 'VariableLookup',
+  Comparison = 'Comparison',
+  LogicalExpression = 'LogicalExpression',
 
   AssignMarkup = 'AssignMarkup',
   PaginateMarkup = 'PaginateMarkup',
@@ -57,6 +59,18 @@ export enum NamedTags {
   include = 'include',
   form = 'form',
   paginate = 'paginate',
+  if = 'if',
+  unless = 'unless',
+}
+
+export enum Comparators {
+  CONTAINS = 'contains',
+  EQUAL = '==',
+  GREATER_THAN = '>',
+  GREATER_THAN_OR_EQUAL = '>=',
+  LESS_THAN = '<',
+  LESS_THAN_OR_EQUAL = '<=',
+  NOT_EQUAL = '!=',
 }
 
 export const HtmlNodeTypes = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,14 +52,15 @@ export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
 
 // These are officially supported with special node types
 export enum NamedTags {
-  echo = 'echo',
-  section = 'section',
   assign = 'assign',
-  render = 'render',
-  include = 'include',
+  echo = 'echo',
+  elsif = 'elsif',
   form = 'form',
-  paginate = 'paginate',
   if = 'if',
+  include = 'include',
+  paginate = 'paginate',
+  render = 'render',
+  section = 'section',
   unless = 'unless',
 }
 
@@ -189,6 +190,10 @@ export type LiquidRawTag = Augmented<AST.LiquidRawTag, AllAugmentations>;
 export type LiquidTag = Augmented<AST.LiquidTag, AllAugmentations>;
 export type LiquidTagNamed = Augmented<AST.LiquidTagNamed, AllAugmentations>;
 export type LiquidBranch = Augmented<AST.LiquidBranch, AllAugmentations>;
+export type LiquidBranchNamed = Augmented<
+  AST.LiquidBranchNamed,
+  AllAugmentations
+>;
 export type LiquidDrop = Augmented<AST.LiquidDrop, AllAugmentations>;
 export type HtmlNode = Augmented<AST.HtmlNode, AllAugmentations>;
 export type HtmlTag = Exclude<HtmlNode, HtmlComment>;

--- a/test/liquid-tag-elsif/fixed.liquid
+++ b/test/liquid-tag-elsif/fixed.liquid
@@ -1,0 +1,70 @@
+It should not break singular expressions, but we break children
+printWidth: 1
+{% if false %}
+{% elsif x %}
+  hello
+{% endif %}
+{% if false %}
+{% elsif 'string' %}
+  hello
+{% endif %}
+{% if false %}
+{% elsif nil %}
+  hello
+{% endif %}
+
+It should break before logical operators
+printWidth: 1
+{% if false %}
+{% elsif conditionA
+  and var.key
+  and true
+%}
+  hello
+{% endif %}
+
+It should break before comparators (and indent)
+printWidth: 1
+{% if false %}
+{% elsif lower
+    < some.variable
+  and some.variable
+    < upper
+%}
+  hello
+{% endif %}
+
+It should try to keep comparators on same line
+printWidth: 30
+{% if false %}
+{% elsif lower < some.variable
+  and some.variable < upper
+%}
+  hello
+{% endif %}
+
+It should support all kinds of shit
+printWidth: 30
+{% if false %}
+{% elsif lower < some.variable
+  and some.variable < upper
+  and string contains 'hi'
+  or string == empty
+  or nil
+  or var.lookup
+%}
+  hello
+{% endif %}
+
+It should support all kinds of shit (same but for unless)
+printWidth: 30
+{% unless false %}
+{% elsif lower < some.variable
+  and some.variable < upper
+  and string contains 'hi'
+  or string == empty
+  or nil
+  or var.lookup
+%}
+  hello
+{% endunless %}

--- a/test/liquid-tag-elsif/index.liquid
+++ b/test/liquid-tag-elsif/index.liquid
@@ -1,0 +1,25 @@
+It should not break singular expressions, but we break children
+printWidth: 1
+{% if false %} {% elsif x %} hello {% endif %}
+{% if false %} {% elsif  'string'%} hello {% endif %}
+{% if false %} {% elsif   nil  %} hello {% endif %}
+
+It should break before logical operators
+printWidth: 1
+{% if false %} {% elsif conditionA and var[ "key" ] and true %} hello {% endif %}
+
+It should break before comparators (and indent)
+printWidth: 1
+{% if false %} {% elsif lower < some.variable and some.variable < upper %} hello {% endif %}
+
+It should try to keep comparators on same line
+printWidth: 30
+{% if false %} {% elsif lower < some.variable and some.variable < upper %} hello {% endif %}
+
+It should support all kinds of shit
+printWidth: 30
+{% if false %} {% elsif lower < some.variable and some.variable < upper and string contains "hi" or string == empty or nil or var.lookup %} hello {% endif %}
+
+It should support all kinds of shit (same but for unless)
+printWidth: 30
+{% unless false %} {% elsif lower < some.variable and some.variable < upper and string contains 'hi' or string == empty or nil or var.lookup %} hello {% endunless %}

--- a/test/liquid-tag-elsif/index.spec.ts
+++ b/test/liquid-tag-elsif/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-if/fixed.liquid
+++ b/test/liquid-tag-if/fixed.liquid
@@ -1,0 +1,63 @@
+It should not break singular expressions, but we break children
+printWidth: 1
+{% if x %}
+  hello
+{% endif %}
+{% if 'string' %}
+  hello
+{% endif %}
+{% if nil %}
+  hello
+{% endif %}
+
+It should break before logical operators
+printWidth: 1
+{% if conditionA
+  and var.key
+  and true
+%}
+  hello
+{% endif %}
+
+It should break before comparators (and indent)
+printWidth: 1
+{% if lower
+    < some.variable
+  and some.variable
+    < upper
+%}
+  hello
+{% endif %}
+
+It should try to keep comparators on same line
+printWidth: 30
+{% if lower < some.variable
+  and some.variable < upper
+%}
+  hello
+{% endif %}
+
+It should support all kinds of shit
+printWidth: 30
+{% if lower < some.variable
+  and some.variable < upper
+  and string contains 'hi'
+  or string == empty
+  or nil
+  or var.lookup
+%}
+  hello
+{% endif %}
+
+It should support all kinds of shit (same but for unless)
+printWidth: 30
+{% unless lower
+    < some.variable
+  and some.variable < upper
+  and string contains 'hi'
+  or string == empty
+  or nil
+  or var.lookup
+%}
+  hello
+{% endunless %}

--- a/test/liquid-tag-if/index.liquid
+++ b/test/liquid-tag-if/index.liquid
@@ -1,0 +1,25 @@
+It should not break singular expressions, but we break children
+printWidth: 1
+{% if x %} hello {% endif %}
+{% if  'string'%} hello {% endif %}
+{% if   nil  %} hello {% endif %}
+
+It should break before logical operators
+printWidth: 1
+{% if conditionA and var[ "key" ] and true %} hello {% endif %}
+
+It should break before comparators (and indent)
+printWidth: 1
+{% if lower < some.variable and some.variable < upper %} hello {% endif %}
+
+It should try to keep comparators on same line
+printWidth: 30
+{% if lower < some.variable and some.variable < upper %} hello {% endif %}
+
+It should support all kinds of shit
+printWidth: 30
+{% if lower < some.variable and some.variable < upper and string contains "hi" or string == empty or nil or var.lookup %} hello {% endif %}
+
+It should support all kinds of shit (same but for unless)
+printWidth: 30
+{% unless lower < some.variable and some.variable < upper and string contains 'hi' or string == empty or nil or var.lookup %} hello {% endunless %}

--- a/test/liquid-tag-if/index.spec.ts
+++ b/test/liquid-tag-if/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Prevent liquidVariableLookup from matching on empty string
- Add support for `if` and `unless` tags
- Add support for `elsif` tag

## Decisions

- `{% if $firstCondition` on first line
- maybe break other conditions on new lines (with logical operator on the new line)
- maybe break comparator on new lines
- `%}` on new line if breaking

## Examples

```liquid
It should break before comparators (and indent)
printWidth: 1
{% if lower
    < some.variable
  and some.variable
    < upper
%}
  hello
{% endif %}

It should try to keep comparators on same line
printWidth: 30
{% if lower < some.variable
  and some.variable < upper
%}
  hello
{% endif %}

It should support all kinds of shit
printWidth: 30
{% if false %}
{% elsif lower < some.variable
  and some.variable < upper
  and string contains 'hi'
  or string == empty
  or nil
  or var.lookup
%}
  hello
{% endif %}

```

Fixes #62
