### PR TITLE
Add support for `case` and `when` tags

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -84,12 +84,13 @@ LiquidHTML {
     | liquidTagOpenBaseCase
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
-    | liquidTagEcho
     | liquidTagAssign
+    | liquidTagEcho
     | liquidTagElsif
-    | liquidTagRender
     | liquidTagInclude
+    | liquidTagRender
     | liquidTagSection
+    | liquidTagWhen
     | liquidTagBaseCase
 
   // These two are the same but transformed differently
@@ -124,6 +125,10 @@ LiquidHTML {
 
   liquidTagOpenCase = liquidTagOpenRule<"case", liquidTagOpenCaseMarkup>
   liquidTagOpenCaseMarkup = liquidExpression space*
+
+  liquidTagWhen = liquidTagRule<"when", liquidTagWhenMarkup>
+  liquidTagWhenMarkup = nonemptyListOf<liquidExpression, whenMarkupSep> space*
+  whenMarkupSep = space* ("," | "or" ~identifier) space*
 
   liquidTagOpenIf = liquidTagOpenRule<"if", liquidTagOpenConditionalMarkup>
   liquidTagOpenUnless = liquidTagOpenRule<"unless", liquidTagOpenConditionalMarkup>

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -76,10 +76,11 @@ LiquidHTML {
   liquidNode = liquidRawTag | liquidDrop | liquidTagClose | liquidTagOpen | liquidTag | liquidInlineComment
 
   liquidTagOpen =
+    | liquidTagOpenCase
     | liquidTagOpenForm
     | liquidTagOpenIf
-    | liquidTagOpenUnless
     | liquidTagOpenPaginate
+    | liquidTagOpenUnless
     | liquidTagOpenBaseCase
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
@@ -120,6 +121,9 @@ LiquidHTML {
 
   liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
   liquidTagOpenFormMarkup = arguments space*
+
+  liquidTagOpenCase = liquidTagOpenRule<"case", liquidTagOpenCaseMarkup>
+  liquidTagOpenCaseMarkup = liquidExpression space*
 
   liquidTagOpenIf = liquidTagOpenRule<"if", liquidTagOpenConditionalMarkup>
   liquidTagOpenUnless = liquidTagOpenRule<"unless", liquidTagOpenConditionalMarkup>

--- a/src/parser/ast.spec.ts
+++ b/src/parser/ast.spec.ts
@@ -660,7 +660,7 @@ describe('Unit: toLiquidHtmlAST', () => {
   });
 
   it('should parse liquid case as branches', () => {
-    ast = toLiquidHtmlAST(`{% case A %}{% when A %}A{% when B %}B{% else %}C{% endcase %}`);
+    ast = toLiquidHtmlAST(`{% case A %}{% when A %}A{% when "B" %}B{% else %}C{% endcase %}`);
     expectPath(ast, 'children.0').to.exist;
     expectPath(ast, 'children.0.type').to.eql('LiquidTag');
     expectPath(ast, 'children.0.name').to.eql('case');
@@ -675,13 +675,14 @@ describe('Unit: toLiquidHtmlAST', () => {
     expectPath(ast, 'children.0.children.1').to.exist;
     expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
     expectPath(ast, 'children.0.children.1.name').to.eql('when');
-    expectPath(ast, 'children.0.children.1.markup').to.eql('A');
+    expectPath(ast, 'children.0.children.1.markup').to.have.lengthOf(1);
+    expectPath(ast, 'children.0.children.1.markup.0.type').to.equal('VariableLookup');
     expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
     expectPath(ast, 'children.0.children.1.children.0.value').to.eql('A');
 
     expectPath(ast, 'children.0.children.2.type').to.eql('LiquidBranch');
     expectPath(ast, 'children.0.children.2.name').to.eql('when');
-    expectPath(ast, 'children.0.children.2.markup').to.eql('B');
+    expectPath(ast, 'children.0.children.2.markup.0.type').to.equal('String');
     expectPath(ast, 'children.0.children.2.children.0.type').to.eql('TextNode');
     expectPath(ast, 'children.0.children.2.children.0.value').to.eql('B');
 

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -158,6 +158,8 @@ export interface AssignMarkup extends ASTNode<NodeTypes.AssignMarkup> {
 
 export interface LiquidTagCase
   extends LiquidTagNode<NamedTags.case, LiquidExpression> {}
+export interface LiquidBranchWhen
+  extends LiquidBranchNode<NamedTags.when, LiquidExpression[]> {}
 
 export interface LiquidTagForm
   extends LiquidTagNode<NamedTags.form, LiquidArgument[]> {}
@@ -221,7 +223,7 @@ export type LiquidBranch =
   | LiquidBranchUnnamed
   | LiquidBranchBaseCase
   | LiquidBranchNamed;
-export type LiquidBranchNamed = LiquidBranchElsif;
+export type LiquidBranchNamed = LiquidBranchElsif | LiquidBranchWhen;
 
 interface LiquidBranchNode<Name, Markup>
   extends ASTNode<NodeTypes.LiquidBranch> {
@@ -860,6 +862,14 @@ function toNamedLiquidTag(
         name: node.name,
         markup: toExpression(node.markup, source),
         children: [],
+      };
+    }
+
+    case NamedTags.when: {
+      return {
+        ...liquidBranchBaseAttributes(node, source),
+        name: node.name,
+        markup: node.markup.map((arg) => toExpression(arg, source)),
       };
     }
 

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -115,6 +115,7 @@ export interface LiquidRawTag extends ASTNode<NodeTypes.LiquidRawTag> {
 export type LiquidTag = LiquidTagNamed | LiquidTagBaseCase;
 export type LiquidTagNamed =
   | LiquidTagAssign
+  | LiquidTagCase
   | LiquidTagEcho
   | LiquidTagForm
   | LiquidTagIf
@@ -154,6 +155,9 @@ export interface AssignMarkup extends ASTNode<NodeTypes.AssignMarkup> {
   name: string;
   value: LiquidVariable;
 }
+
+export interface LiquidTagCase
+  extends LiquidTagNode<NamedTags.case, LiquidExpression> {}
 
 export interface LiquidTagForm
   extends LiquidTagNode<NamedTags.form, LiquidArgument[]> {}
@@ -847,6 +851,15 @@ function toNamedLiquidTag(
         ...liquidBranchBaseAttributes(node, source),
         name: node.name,
         markup: toConditionalExpression(node.markup, source),
+      };
+    }
+
+    case NamedTags.case: {
+      return {
+        ...liquidTagBaseAttributes(node, source),
+        name: node.name,
+        markup: toExpression(node.markup, source),
+        children: [],
       };
     }
 

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -576,6 +576,20 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should parse case arguments as a singular liquid expression', () => {
+      [
+        { expression: `"string"`, type: 'String' },
+        { expression: `var.lookup`, type: 'VariableLookup' },
+      ].forEach(({ expression, type }) => {
+        cst = toLiquidHtmlCST(`{% case ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+        expectPath(cst, '0.name').to.equal('case');
+        expectPath(cst, '0.markup.type').to.equal(type);
+        expectLocation(cst, '0');
+        expectLocation(cst, '0.markup');
+      });
+    });
+
     it('should parse the paginate tag open markup as arguments', () => {
       [
         {

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -590,6 +590,30 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should parse when arguments as an array of liquid expressions', () => {
+      [
+        { expression: `"string"`, args: [{ type: 'String' }] },
+        {
+          expression: `"string", var.lookup`,
+          args: [{ type: 'String' }, { type: 'VariableLookup' }],
+        },
+        {
+          expression: `"string" or var.lookup`,
+          args: [{ type: 'String' }, { type: 'VariableLookup' }],
+        },
+      ].forEach(({ expression, args }) => {
+        cst = toLiquidHtmlCST(`{% when ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTag');
+        expectPath(cst, '0.name').to.equal('when');
+        expectPath(cst, '0.markup').to.have.lengthOf(args.length);
+        args.forEach((arg, i) => {
+          expectPath(cst, `0.markup.${i}.type`).to.equal(arg.type);
+          expectLocation(cst, `0.markup.${i}`);
+        });
+        expectLocation(cst, '0');
+      });
+    });
+
     it('should parse the paginate tag open markup as arguments', () => {
       [
         {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -141,6 +141,7 @@ export type ConcreteLiquidTagOpen =
   | ConcreteLiquidTagOpenBaseCase
   | ConcreteLiquidTagOpenNamed;
 export type ConcreteLiquidTagOpenNamed =
+  | ConcreteLiquidTagOpenCase
   | ConcreteLiquidTagOpenIf
   | ConcreteLiquidTagOpenUnless
   | ConcreteLiquidTagOpenForm
@@ -154,6 +155,9 @@ export interface ConcreteLiquidTagOpenNode<Name, Markup>
 
 export interface ConcreteLiquidTagOpenBaseCase
   extends ConcreteLiquidTagOpenNode<string, string> {}
+
+export interface ConcreteLiquidTagOpenCase
+  extends ConcreteLiquidTagOpenNode<NamedTags.case, ConcreteLiquidExpression> {}
 
 export interface ConcreteLiquidTagOpenIf
   extends ConcreteLiquidTagOpenNode<NamedTags.if, ConcreteLiquidCondition[]> {}
@@ -500,6 +504,8 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locStart,
       locEnd,
     },
+    liquidTagOpenCase: 0,
+    liquidTagOpenCaseMarkup: 0,
     liquidTagOpenIf: 0,
     liquidTagOpenUnless: 0,
     liquidTagElsif: 0,

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -158,6 +158,8 @@ export interface ConcreteLiquidTagOpenBaseCase
 
 export interface ConcreteLiquidTagOpenCase
   extends ConcreteLiquidTagOpenNode<NamedTags.case, ConcreteLiquidExpression> {}
+export interface ConcreteLiquidTagWhen
+  extends ConcreteLiquidTagNode<NamedTags.when, ConcreteLiquidExpression[]> {}
 
 export interface ConcreteLiquidTagOpenIf
   extends ConcreteLiquidTagOpenNode<NamedTags.if, ConcreteLiquidCondition[]> {}
@@ -212,7 +214,8 @@ export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagElsif
   | ConcreteLiquidTagInclude
   | ConcreteLiquidTagRender
-  | ConcreteLiquidTagSection;
+  | ConcreteLiquidTagSection
+  | ConcreteLiquidTagWhen;
 
 export interface ConcreteLiquidTagNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
@@ -506,6 +509,8 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     },
     liquidTagOpenCase: 0,
     liquidTagOpenCaseMarkup: 0,
+    liquidTagWhen: 0,
+    liquidTagWhenMarkup: 0,
     liquidTagOpenIf: 0,
     liquidTagOpenUnless: 0,
     liquidTagElsif: 0,

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -112,6 +112,24 @@ function printNamedLiquidBlock(
       '%}',
     ]);
 
+  const tagWithArrayMarkup = (whitespace: Doc) =>
+    group([
+      '{%',
+      whitespaceStart,
+      ' ',
+      node.name,
+      ' ',
+      indent([
+        join(
+          [',', line],
+          path.map((p) => print(p), 'markup'),
+        ),
+      ]),
+      whitespace,
+      whitespaceEnd,
+      '%}',
+    ]);
+
   switch (node.name) {
     case NamedTags.echo: {
       const whitespace = node.markup.filters.length > 0 ? line : ' ';
@@ -138,24 +156,8 @@ function printNamedLiquidBlock(
     }
 
     case NamedTags.form: {
-      const args = node.markup;
-      const whitespace = args.length > 1 ? line : ' ';
-      return group([
-        '{%',
-        whitespaceStart,
-        ' ',
-        node.name,
-        ' ',
-        indent([
-          join(
-            [',', line],
-            path.map((p) => print(p), 'markup'),
-          ),
-        ]),
-        whitespace,
-        whitespaceEnd,
-        '%}',
-      ]);
+      const whitespace = node.markup.length > 1 ? line : ' ';
+      return tagWithArrayMarkup(whitespace);
     }
 
     case NamedTags.paginate: {
@@ -176,6 +178,11 @@ function printNamedLiquidBlock(
 
     case NamedTags.case: {
       return tag(' ');
+    }
+
+    case NamedTags.when: {
+      const whitespace = node.markup.length > 1 ? line : ' ';
+      return tagWithArrayMarkup(whitespace);
     }
 
     default: {

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -174,6 +174,10 @@ function printNamedLiquidBlock(
       return tag(whitespace);
     }
 
+    case NamedTags.case: {
+      return tag(' ');
+    }
+
     default: {
       return assertNever(node);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
 // These are officially supported with special node types
 export enum NamedTags {
   assign = 'assign',
+  case = 'case',
   echo = 'echo',
   elsif = 'elsif',
   form = 'form',

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export enum NamedTags {
   render = 'render',
   section = 'section',
   unless = 'unless',
+  when = 'when',
 }
 
 export enum Comparators {

--- a/test/liquid-tag-case/fixed.liquid
+++ b/test/liquid-tag-case/fixed.liquid
@@ -1,0 +1,10 @@
+It should never break a name
+printWidth: 1
+{% case 'name' %}
+{% endcase %}
+{% case true %}
+{% endcase %}
+{% case var.lookup %}
+{% endcase %}
+{%- case var.lookup -%}
+{% endcase %}

--- a/test/liquid-tag-case/fixed.liquid
+++ b/test/liquid-tag-case/fixed.liquid
@@ -8,3 +8,31 @@ printWidth: 1
 {% endcase %}
 {%- case var.lookup -%}
 {% endcase %}
+
+It should break and indent when statements, and not break the when
+printWidth: 1
+{% case candy.type %}
+  {% when 'gummy bears' %}
+    yum!
+{% endcase %}
+
+It should break on when comma syntax
+printWidth: 1
+{% case candy.type %}
+  {% when 'gummy bears',
+    'chocolate'
+  %}
+    yum!
+{% endcase %}
+
+It should break on when or syntax (and prefer commas)
+printWidth: 1
+{% case candy.type %}
+  {% when 'gummy bears',
+    'chocolate',
+    'chips'
+  %}
+    yum!
+  {% else %}
+    ok!
+{% endcase %}

--- a/test/liquid-tag-case/index.liquid
+++ b/test/liquid-tag-case/index.liquid
@@ -6,3 +6,15 @@ printWidth: 1
 {%- case
 var.lookup
 -%} {% endcase %}
+
+It should break and indent when statements, and not break the when
+printWidth: 1
+{% case candy.type %} {% when "gummy bears" %} yum! {% endcase %}
+
+It should break on when comma syntax
+printWidth: 1
+{% case candy.type %} {% when "gummy bears", "chocolate" %} yum! {% endcase %}
+
+It should break on when or syntax (and prefer commas)
+printWidth: 1
+{% case candy.type %} {% when "gummy bears" or "chocolate" or "chips" %} yum! {% else %} ok! {% endcase %}

--- a/test/liquid-tag-case/index.liquid
+++ b/test/liquid-tag-case/index.liquid
@@ -1,0 +1,8 @@
+It should never break on case expression
+printWidth: 1
+{% case  "name"  %} {% endcase %}
+{% case true %} {% endcase %}
+{%case var.lookup %} {% endcase %}
+{%- case
+var.lookup
+-%} {% endcase %}

--- a/test/liquid-tag-case/index.spec.ts
+++ b/test/liquid-tag-case/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Add support for `case` tag
- Add support for `when` tag

## Decisions

- Never break `case`
- Only break `when` when the undocumented comma or `or` syntax is used
  - Same way as the others

## Examples

```liquid
It should break and indent when statements, and not break the when
printWidth: 1
{% case candy.type %}
  {% when 'gummy bears' %}
    yum!
  {% else %}
    ok!
{% endcase %}

It should break on when comma syntax
printWidth: 1
{% case candy.type %}
  {% when 'gummy bears',
    'chocolate'
  %}
    yum!
  {% else %}
    ok!
{% endcase %}

It should break on when or syntax (and prefer commas)
printWidth: 1
{% case candy.type %}
  {% when 'gummy bears',
    'chocolate',
    'chips'
  %}
    yum!
  {% else %}
    ok!
{% endcase %}
```
