### PR TITLE
Add support for `for` and `tablerow` tags

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -78,6 +78,7 @@ LiquidHTML {
   liquidTagOpen =
     | liquidTagOpenCase
     | liquidTagOpenForm
+    | liquidTagOpenFor
     | liquidTagOpenIf
     | liquidTagOpenPaginate
     | liquidTagOpenUnless
@@ -122,6 +123,12 @@ LiquidHTML {
 
   liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
   liquidTagOpenFormMarkup = arguments space*
+
+  liquidTagOpenFor = liquidTagOpenRule<"for", liquidTagOpenForMarkup>
+  liquidTagOpenForMarkup =
+    variableSegment space* "in" space* liquidExpression
+    (space* "reversed")? argumentSeparatorOptionalComma
+    tagArguments space*
 
   liquidTagOpenCase = liquidTagOpenRule<"case", liquidTagOpenCaseMarkup>
   liquidTagOpenCaseMarkup = liquidExpression space*

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -79,6 +79,7 @@ LiquidHTML {
     | liquidTagOpenCase
     | liquidTagOpenForm
     | liquidTagOpenFor
+    | liquidTagOpenTablerow
     | liquidTagOpenIf
     | liquidTagOpenPaginate
     | liquidTagOpenUnless
@@ -129,6 +130,9 @@ LiquidHTML {
     variableSegment space* "in" space* liquidExpression
     (space* "reversed")? argumentSeparatorOptionalComma
     tagArguments space*
+
+  // It's the same, the difference is support for different named arguments
+  liquidTagOpenTablerow = liquidTagOpenRule<"tablerow", liquidTagOpenForMarkup>
 
   liquidTagOpenCase = liquidTagOpenRule<"case", liquidTagOpenCaseMarkup>
   liquidTagOpenCaseMarkup = liquidExpression space*

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -126,6 +126,7 @@ export type LiquidTagNamed =
   | LiquidTagPaginate
   | LiquidTagRender
   | LiquidTagSection
+  | LiquidTagTablerow
   | LiquidTagUnless;
 
 export interface LiquidTagNode<Name, Markup>
@@ -174,6 +175,9 @@ export interface ForMarkup extends ASTNode<NodeTypes.ForMarkup> {
   reversed: boolean;
   args: LiquidNamedArgument[];
 }
+
+export interface LiquidTagTablerow
+  extends LiquidTagNode<NamedTags.tablerow, ForMarkup> {}
 
 export interface LiquidTagIf extends LiquidTagConditional<NamedTags.if> {}
 export interface LiquidTagUnless
@@ -840,6 +844,7 @@ function toNamedLiquidTag(
       };
     }
 
+    case NamedTags.tablerow:
     case NamedTags.for: {
       return {
         ...liquidTagBaseAttributes(node, source),

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -576,58 +576,67 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
-    it('should parse the for tag open markup as ForMarkup', () => {
-      [
-        {
-          expression: `product in all_products`,
-          variableName: 'product',
-          collection: { type: 'VariableLookup' },
-          reversed: null,
-          args: [],
-        },
-        {
-          expression: `product in all_products reversed`,
-          variableName: 'product',
-          collection: { type: 'VariableLookup' },
-          reversed: 'reversed',
-          args: [],
-        },
-        {
-          expression: `product in all_products limit: 10`,
-          variableName: 'product',
-          collection: { type: 'VariableLookup' },
-          reversed: null,
-          args: [{ type: 'NamedArgument', name: 'limit', value: { type: 'Number' } }],
-        },
-        {
-          expression: `product in all_products reversed limit: 10 offset:var`,
-          variableName: 'product',
-          collection: { type: 'VariableLookup' },
-          reversed: 'reversed',
-          args: [
-            { type: 'NamedArgument', name: 'limit', value: { type: 'Number' } },
-            { type: 'NamedArgument', name: 'offset', value: { type: 'VariableLookup' } },
-          ],
-        },
-      ].forEach(({ expression, variableName, collection, reversed, args }) => {
-        cst = toLiquidHtmlCST(`{% for ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-        expectPath(cst, '0.name').to.equal('for');
-        expectPath(cst, '0.markup.type').to.equal('ForMarkup');
-        expectPath(cst, '0.markup.variableName').to.equal(variableName);
-        expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
-        expectPath(cst, '0.markup.reversed').to.equal(reversed);
-        expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
-        args.forEach((arg, i) => {
-          expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
-          expectPath(cst, `0.markup.args.${i}.name`).to.equal(arg.name);
-          expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.value.type);
-          expectLocation(cst, `0.markup.args.${i}`);
-          expectLocation(cst, `0.markup.args.${i}.value`);
+    it('should parse the for and tablerow tags open markup as ForMarkup', () => {
+      ['for', 'tablerow'].forEach((tagName) => {
+        [
+          {
+            expression: `product in all_products`,
+            variableName: 'product',
+            collection: { type: 'VariableLookup' },
+            reversed: null,
+            args: [],
+          },
+          {
+            expression: `i in (0..x)`,
+            variableName: 'i',
+            collection: { type: 'Range' },
+            reversed: null,
+            args: [],
+          },
+          {
+            expression: `product in all_products reversed`,
+            variableName: 'product',
+            collection: { type: 'VariableLookup' },
+            reversed: 'reversed',
+            args: [],
+          },
+          {
+            expression: `product in all_products limit: 10`,
+            variableName: 'product',
+            collection: { type: 'VariableLookup' },
+            reversed: null,
+            args: [{ type: 'NamedArgument', name: 'limit', value: { type: 'Number' } }],
+          },
+          {
+            expression: `product in all_products reversed limit: 10 offset:var`,
+            variableName: 'product',
+            collection: { type: 'VariableLookup' },
+            reversed: 'reversed',
+            args: [
+              { type: 'NamedArgument', name: 'limit', value: { type: 'Number' } },
+              { type: 'NamedArgument', name: 'offset', value: { type: 'VariableLookup' } },
+            ],
+          },
+        ].forEach(({ expression, variableName, collection, reversed, args }) => {
+          cst = toLiquidHtmlCST(`{% ${tagName} ${expression} -%}`);
+          expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+          expectPath(cst, '0.name').to.equal(tagName);
+          expectPath(cst, '0.markup.type').to.equal('ForMarkup');
+          expectPath(cst, '0.markup.variableName').to.equal(variableName);
+          expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
+          expectPath(cst, '0.markup.reversed').to.equal(reversed);
+          expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+          args.forEach((arg, i) => {
+            expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
+            expectPath(cst, `0.markup.args.${i}.name`).to.equal(arg.name);
+            expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.value.type);
+            expectLocation(cst, `0.markup.args.${i}`);
+            expectLocation(cst, `0.markup.args.${i}.value`);
+          });
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectLocation(cst, '0');
+          expectLocation(cst, `0.markup`);
         });
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-        expectLocation(cst, '0');
-        expectLocation(cst, `0.markup`);
       });
     });
 

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -576,6 +576,61 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should parse the for tag open markup as ForMarkup', () => {
+      [
+        {
+          expression: `product in all_products`,
+          variableName: 'product',
+          collection: { type: 'VariableLookup' },
+          reversed: null,
+          args: [],
+        },
+        {
+          expression: `product in all_products reversed`,
+          variableName: 'product',
+          collection: { type: 'VariableLookup' },
+          reversed: 'reversed',
+          args: [],
+        },
+        {
+          expression: `product in all_products limit: 10`,
+          variableName: 'product',
+          collection: { type: 'VariableLookup' },
+          reversed: null,
+          args: [{ type: 'NamedArgument', name: 'limit', value: { type: 'Number' } }],
+        },
+        {
+          expression: `product in all_products reversed limit: 10 offset:var`,
+          variableName: 'product',
+          collection: { type: 'VariableLookup' },
+          reversed: 'reversed',
+          args: [
+            { type: 'NamedArgument', name: 'limit', value: { type: 'Number' } },
+            { type: 'NamedArgument', name: 'offset', value: { type: 'VariableLookup' } },
+          ],
+        },
+      ].forEach(({ expression, variableName, collection, reversed, args }) => {
+        cst = toLiquidHtmlCST(`{% for ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+        expectPath(cst, '0.name').to.equal('for');
+        expectPath(cst, '0.markup.type').to.equal('ForMarkup');
+        expectPath(cst, '0.markup.variableName').to.equal(variableName);
+        expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
+        expectPath(cst, '0.markup.reversed').to.equal(reversed);
+        expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+        args.forEach((arg, i) => {
+          expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
+          expectPath(cst, `0.markup.args.${i}.name`).to.equal(arg.name);
+          expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.value.type);
+          expectLocation(cst, `0.markup.args.${i}`);
+          expectLocation(cst, `0.markup.args.${i}.value`);
+        });
+        expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        expectLocation(cst, '0');
+        expectLocation(cst, `0.markup`);
+      });
+    });
+
     it('should parse case arguments as a singular liquid expression', () => {
       [
         { expression: `"string"`, type: 'String' },

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -147,7 +147,8 @@ export type ConcreteLiquidTagOpenNamed =
   | ConcreteLiquidTagOpenUnless
   | ConcreteLiquidTagOpenForm
   | ConcreteLiquidTagOpenFor
-  | ConcreteLiquidTagOpenPaginate;
+  | ConcreteLiquidTagOpenPaginate
+  | ConcreteLiquidTagOpenTablerow;
 
 export interface ConcreteLiquidTagOpenNode<Name, Markup>
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagOpen> {
@@ -201,6 +202,12 @@ export interface ConcreteLiquidTagForMarkup
   reversed: 'reversed' | null;
   args: ConcreteLiquidNamedArgument[];
 }
+
+export interface ConcreteLiquidTagOpenTablerow
+  extends ConcreteLiquidTagOpenNode<
+    NamedTags.tablerow,
+    ConcreteLiquidTagForMarkup
+  > {}
 
 export interface ConcreteLiquidTagOpenPaginate
   extends ConcreteLiquidTagOpenNode<
@@ -523,6 +530,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locStart,
       locEnd,
     },
+    liquidTagOpenTablerow: 0,
     liquidTagOpenPaginate: 0,
     liquidTagOpenPaginateMarkup: {
       type: ConcreteNodeTypes.PaginateMarkup,

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -36,6 +36,7 @@ export enum ConcreteNodeTypes {
   Condition = 'Condition',
 
   AssignMarkup = 'AssignMarkup',
+  ForMarkup = 'ForMarkup',
   RenderMarkup = 'RenderMarkup',
   PaginateMarkup = 'PaginateMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
@@ -145,6 +146,7 @@ export type ConcreteLiquidTagOpenNamed =
   | ConcreteLiquidTagOpenIf
   | ConcreteLiquidTagOpenUnless
   | ConcreteLiquidTagOpenForm
+  | ConcreteLiquidTagOpenFor
   | ConcreteLiquidTagOpenPaginate;
 
 export interface ConcreteLiquidTagOpenNode<Name, Markup>
@@ -186,6 +188,19 @@ export interface ConcreteLiquidComparison
 
 export interface ConcreteLiquidTagOpenForm
   extends ConcreteLiquidTagOpenNode<NamedTags.form, ConcreteLiquidArgument[]> {}
+
+export interface ConcreteLiquidTagOpenFor
+  extends ConcreteLiquidTagOpenNode<
+    NamedTags.for,
+    ConcreteLiquidTagForMarkup
+  > {}
+export interface ConcreteLiquidTagForMarkup
+  extends ConcreteBasicNode<ConcreteNodeTypes.ForMarkup> {
+  variableName: string;
+  collection: ConcreteLiquidExpression;
+  reversed: 'reversed' | null;
+  args: ConcreteLiquidNamedArgument[];
+}
 
 export interface ConcreteLiquidTagOpenPaginate
   extends ConcreteLiquidTagOpenNode<
@@ -498,6 +513,16 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
 
     liquidTagOpenForm: 0,
     liquidTagOpenFormMarkup: 0,
+    liquidTagOpenFor: 0,
+    liquidTagOpenForMarkup: {
+      type: ConcreteNodeTypes.ForMarkup,
+      variableName: 0,
+      collection: 4,
+      reversed: 6,
+      args: 8,
+      locStart,
+      locEnd,
+    },
     liquidTagOpenPaginate: 0,
     liquidTagOpenPaginateMarkup: {
       type: ConcreteNodeTypes.PaginateMarkup,

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -92,6 +92,7 @@ function getCssDisplay(
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
@@ -151,6 +152,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -99,7 +99,7 @@ function printNamedLiquidBlock(
 ): Doc {
   const node = path.getValue();
 
-  const tag = (whitespace: Doc) =>
+  const tag = (trailingWhitespace: Doc) =>
     group([
       '{%',
       whitespaceStart,
@@ -107,7 +107,7 @@ function printNamedLiquidBlock(
       node.name,
       ' ',
       indent(path.call((p) => print(p), 'markup')),
-      whitespace,
+      trailingWhitespace,
       whitespaceEnd,
       '%}',
     ]);
@@ -132,23 +132,24 @@ function printNamedLiquidBlock(
 
   switch (node.name) {
     case NamedTags.echo: {
-      const whitespace = node.markup.filters.length > 0 ? line : ' ';
-      return tag(whitespace);
+      const trailingWhitespace = node.markup.filters.length > 0 ? line : ' ';
+      return tag(trailingWhitespace);
     }
 
     case NamedTags.assign: {
-      const whitespace = node.markup.value.filters.length > 0 ? line : ' ';
-      return tag(whitespace);
+      const trailingWhitespace =
+        node.markup.value.filters.length > 0 ? line : ' ';
+      return tag(trailingWhitespace);
     }
 
     case NamedTags.include:
     case NamedTags.render: {
       const markup = node.markup;
-      const whitespace =
+      const trailingWhitespace =
         markup.args.length > 0 || (markup.variable && markup.alias)
           ? line
           : ' ';
-      return tag(whitespace);
+      return tag(trailingWhitespace);
     }
 
     case NamedTags.section: {
@@ -156,8 +157,14 @@ function printNamedLiquidBlock(
     }
 
     case NamedTags.form: {
-      const whitespace = node.markup.length > 1 ? line : ' ';
-      return tagWithArrayMarkup(whitespace);
+      const trailingWhitespace = node.markup.length > 1 ? line : ' ';
+      return tagWithArrayMarkup(trailingWhitespace);
+    }
+
+    case NamedTags.for: {
+      const trailingWhitespace =
+        node.markup.reversed || node.markup.args.length > 0 ? line : ' ';
+      return tag(trailingWhitespace);
     }
 
     case NamedTags.paginate: {
@@ -167,13 +174,13 @@ function printNamedLiquidBlock(
     case NamedTags.if:
     case NamedTags.elsif:
     case NamedTags.unless: {
-      const whitespace = [
+      const trailingWhitespace = [
         NodeTypes.Comparison,
         NodeTypes.LogicalExpression,
       ].includes(node.markup.type)
         ? line
         : ' ';
-      return tag(whitespace);
+      return tag(trailingWhitespace);
     }
 
     case NamedTags.case: {
@@ -181,8 +188,8 @@ function printNamedLiquidBlock(
     }
 
     case NamedTags.when: {
-      const whitespace = node.markup.length > 1 ? line : ' ';
-      return tagWithArrayMarkup(whitespace);
+      const trailingWhitespace = node.markup.length > 1 ? line : ' ';
+      return tagWithArrayMarkup(trailingWhitespace);
     }
 
     default: {

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -161,6 +161,7 @@ function printNamedLiquidBlock(
       return tagWithArrayMarkup(trailingWhitespace);
     }
 
+    case NamedTags.tablerow:
     case NamedTags.for: {
       const trailingWhitespace =
         node.markup.reversed || node.markup.args.length > 0 ? line : ' ';

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -382,6 +382,26 @@ function printNode(
       return [node.name, ' = ', path.call(print, 'value')];
     }
 
+    case NodeTypes.ForMarkup: {
+      const doc = [node.variableName, ' in ', path.call(print, 'collection')];
+
+      if (node.reversed) {
+        doc.push(line, 'reversed');
+      }
+
+      if (node.args.length > 0) {
+        doc.push([
+          line,
+          join(
+            line,
+            path.map((p) => print(p), 'args'),
+          ),
+        ]);
+      }
+
+      return doc;
+    }
+
     case NodeTypes.PaginateMarkup: {
       const doc = [
         path.call(print, 'collection'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export enum NodeTypes {
   LogicalExpression = 'LogicalExpression',
 
   AssignMarkup = 'AssignMarkup',
+  ForMarkup = 'ForMarkup',
   PaginateMarkup = 'PaginateMarkup',
   RenderMarkup = 'RenderMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
@@ -57,6 +58,7 @@ export enum NamedTags {
   echo = 'echo',
   elsif = 'elsif',
   form = 'form',
+  for = 'for',
   if = 'if',
   include = 'include',
   paginate = 'paginate',

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export enum NamedTags {
   if = 'if',
   include = 'include',
   paginate = 'paginate',
+  tablerow = 'tablerow',
   render = 'render',
   section = 'section',
   unless = 'unless',

--- a/test/liquid-tag-for/fixed.liquid
+++ b/test/liquid-tag-for/fixed.liquid
@@ -1,0 +1,41 @@
+It takes an element and a collection
+{% for element in collection -%}
+{%- endfor %}
+
+It does not breaks on in collection
+printWidth: 1
+{% for element in collection %}
+  {{ collection }}
+{% endfor %}
+
+It breaks on reversed
+printWidth: 1
+{% for element in collection
+  reversed
+%}
+  {{ element }}
+{% endfor %}
+
+It breaks on tag arguments
+printWidth: 1
+{% for element in collection
+  limit: 10
+  offset: 10
+%}
+  {{ element }}
+{% endfor %}
+
+It breaks on both reversed and tag arguments
+printWidth: 1
+{% for element in collection
+  reversed
+  limit: 10
+%}
+  {{ element }}
+{% endfor %}
+
+It only breaks if the printWidth is hit
+printWidth: 80
+{% for element in collection reversed limit: 10 %}
+  {{ element }}
+{% endfor %}

--- a/test/liquid-tag-for/index.liquid
+++ b/test/liquid-tag-for/index.liquid
@@ -1,0 +1,32 @@
+It takes an element and a collection
+{% for element in collection %}{% endfor %}
+
+It does not breaks on in collection
+printWidth: 1
+{% for element in collection %}
+  {{ collection }}
+{% endfor %}
+
+It breaks on reversed
+printWidth: 1
+{% for element in collection reversed %}
+  {{ element }}
+{% endfor %}
+
+It breaks on tag arguments
+printWidth: 1
+{% for element in collection limit: 10 offset: 10 %}
+  {{ element }}
+{% endfor %}
+
+It breaks on both reversed and tag arguments
+printWidth: 1
+{% for element in collection reversed limit: 10 %}
+  {{ element }}
+{% endfor %}
+
+It only breaks if the printWidth is hit
+printWidth: 80
+{% for element in collection reversed limit: 10 %}
+  {{ element }}
+{% endfor %}

--- a/test/liquid-tag-for/index.spec.ts
+++ b/test/liquid-tag-for/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-tablerow/fixed.liquid
+++ b/test/liquid-tag-tablerow/fixed.liquid
@@ -1,0 +1,40 @@
+It takes an element and a collection
+{% tablerow element in collection %}{% endtablerow %}
+
+It does not breaks on in collection
+printWidth: 1
+{% tablerow element in collection %}
+  {{ collection }}
+{% endtablerow %}
+
+It breaks on reversed
+printWidth: 1
+{% tablerow element in collection
+  reversed
+%}
+  {{ element }}
+{% endtablerow %}
+
+It breaks on tag arguments
+printWidth: 1
+{% tablerow element in collection
+  limit: 10
+  offset: 10
+%}
+  {{ element }}
+{% endtablerow %}
+
+It breaks on both reversed and tag argumentsc
+printWidth: 1
+{% tablerow element in collection
+  reversed
+  limit: 10
+%}
+  {{ element }}
+{% endtablerow %}
+
+It only breaks if the printWidth is hit
+printWidth: 80
+{% tablerow element in collection reversed limit: 10 %}
+  {{ element }}
+{% endtablerow %}

--- a/test/liquid-tag-tablerow/index.liquid
+++ b/test/liquid-tag-tablerow/index.liquid
@@ -1,0 +1,32 @@
+It takes an element and a collection
+{% tablerow element in collection %}{% endtablerow %}
+
+It does not breaks on in collection
+printWidth: 1
+{% tablerow element in collection %}
+  {{ collection }}
+{% endtablerow %}
+
+It breaks on reversed
+printWidth: 1
+{% tablerow element in collection reversed %}
+  {{ element }}
+{% endtablerow %}
+
+It breaks on tag arguments
+printWidth: 1
+{% tablerow element in collection limit: 10 offset: 10 %}
+  {{ element }}
+{% endtablerow %}
+
+It breaks on both reversed and tag arguments
+printWidth: 1
+{% tablerow element in collection reversed limit: 10 %}
+  {{ element }}
+{% endtablerow %}
+
+It only breaks if the printWidth is hit
+printWidth: 80
+{% tablerow element in collection reversed limit: 10 %}
+  {{ element }}
+{% endtablerow %}

--- a/test/liquid-tag-tablerow/index.spec.ts
+++ b/test/liquid-tag-tablerow/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Add support for the `for` tag
- Add support for `tablerow` tag

## Decisions

- Asked the partner slack and it looks like we only want to break after `for x in col` (unanimously)
- Break after `{% $tag x in collection`
- if there's `reversed` or there are tag arguments
- `%}` on new line for consistency

## Examples

```liquid
It breaks on both reversed and tag arguments
printWidth: 1
{% for element in collection
  reversed
  limit: 10
%}
  {{ element }}
{% endfor %}

It only breaks if the printWidth is hit
printWidth: 80
{% for element in collection reversed limit: 10 %}
  {{ element }}
{% endfor %}
```

Fixes #64

![image](https://user-images.githubusercontent.com/4990691/185437443-c8947101-de2b-420b-a2f4-fae8ff011934.png)