### PR TITLE
Add support for `layout` tag

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -92,6 +92,7 @@ LiquidHTML {
     | liquidTagInclude
     | liquidTagRender
     | liquidTagSection
+    | liquidTagLayout
     | liquidTagWhen
     | liquidTagBaseCase
 
@@ -111,6 +112,9 @@ LiquidHTML {
 
   liquidTagSection = liquidTagRule<"section", liquidTagSectionMarkup>
   liquidTagSectionMarkup = liquidString space*
+
+  liquidTagLayout = liquidTagRule<"layout", liquidTagLayoutMarkup>
+  liquidTagLayoutMarkup = liquidExpression space*
 
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -125,6 +125,7 @@ export type LiquidTagNamed =
   | LiquidTagInclude
   | LiquidTagPaginate
   | LiquidTagRender
+  | LiquidTagLayout
   | LiquidTagSection
   | LiquidTagTablerow
   | LiquidTagUnless;
@@ -220,6 +221,8 @@ export interface LiquidTagInclude
 
 export interface LiquidTagSection
   extends LiquidTagNode<NamedTags.section, LiquidString> {}
+export interface LiquidTagLayout
+  extends LiquidTagNode<NamedTags.layout, LiquidExpression> {}
 
 export interface RenderMarkup extends ASTNode<NodeTypes.RenderMarkup> {
   snippet: LiquidString | LiquidVariableLookup;
@@ -827,6 +830,7 @@ function toNamedLiquidTag(
       };
     }
 
+    case NamedTags.layout:
     case NamedTags.section: {
       return {
         ...liquidTagBaseAttributes(node, source),

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -235,6 +235,7 @@ export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagEcho
   | ConcreteLiquidTagElsif
   | ConcreteLiquidTagInclude
+  | ConcreteLiquidTagLayout
   | ConcreteLiquidTagRender
   | ConcreteLiquidTagSection
   | ConcreteLiquidTagWhen;
@@ -251,6 +252,8 @@ export interface ConcreteLiquidTagEcho
   extends ConcreteLiquidTagNode<NamedTags.echo, ConcreteLiquidVariable> {}
 export interface ConcreteLiquidTagSection
   extends ConcreteLiquidTagNode<NamedTags.section, ConcreteStringLiteral> {}
+export interface ConcreteLiquidTagLayout
+  extends ConcreteLiquidTagNode<NamedTags.layout, ConcreteLiquidExpression> {}
 
 export interface ConcreteLiquidTagAssign
   extends ConcreteLiquidTagNode<
@@ -580,6 +583,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     liquidTagRender: 0,
     liquidTagInclude: 0,
     liquidTagSection: 0,
+    liquidTagLayout: 0,
     liquidTagRule: {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
@@ -598,6 +602,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     },
     liquidTagEchoMarkup: 0,
     liquidTagSectionMarkup: 0,
+    liquidTagLayoutMarkup: 0,
     liquidTagAssignMarkup: {
       type: ConcreteNodeTypes.AssignMarkup,
       name: 0,

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -152,6 +152,7 @@ function printNamedLiquidBlock(
       return tag(trailingWhitespace);
     }
 
+    case NamedTags.layout:
     case NamedTags.section: {
       return tag(' ');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export enum NamedTags {
   for = 'for',
   if = 'if',
   include = 'include',
+  layout = 'layout',
   paginate = 'paginate',
   tablerow = 'tablerow',
   render = 'render',

--- a/test/liquid-tag-layout/fixed.liquid
+++ b/test/liquid-tag-layout/fixed.liquid
@@ -1,0 +1,7 @@
+It should never break a name
+printWidth: 1
+{% layout 'layoutName' %}
+{% layout 'layoutName' %}
+{% layout 'layoutName' %}
+{%- layout 'layoutName' -%}
+{%- layout none -%}

--- a/test/liquid-tag-layout/index.liquid
+++ b/test/liquid-tag-layout/index.liquid
@@ -1,0 +1,9 @@
+It should never break a name
+printWidth: 1
+{% layout  "layoutName"  %}
+{% layout "layoutName" %}
+{%layout "layoutName"%}
+{%- layout
+"layoutName"
+-%}
+{%- layout none -%}

--- a/test/liquid-tag-layout/index.spec.ts
+++ b/test/liquid-tag-layout/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
Same as `section` tag.

Only one arg, but it's a `liquidExpression` this time.

Fixes #65
