### PR TITLE
Add support for the `cycle` tag

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -87,6 +87,7 @@ LiquidHTML {
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
   liquidTag =
     | liquidTagAssign
+    | liquidTagCycle
     | liquidTagEcho
     | liquidTagElsif
     | liquidTagInclude
@@ -109,6 +110,9 @@ LiquidHTML {
 
   liquidTagAssign = liquidTagRule<"assign", liquidTagAssignMarkup>
   liquidTagAssignMarkup = variableSegment space* "=" space* liquidVariable
+
+  liquidTagCycle = liquidTagRule<"cycle", liquidTagCycleMarkup>
+  liquidTagCycleMarkup = (liquidExpression ":")? space* nonemptyListOf<liquidExpression, argumentSeparator> space*
 
   liquidTagSection = liquidTagRule<"section", liquidTagSectionMarkup>
   liquidTagSectionMarkup = liquidString space*

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -469,6 +469,41 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should parse the cycle tag as cycle markup', () => {
+      [
+        {
+          expression: `a, "string", 10`,
+          groupName: null,
+          args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
+        },
+        {
+          expression: `var: a, "string", 10`,
+          groupName: { type: 'VariableLookup' },
+          args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
+        },
+      ].forEach(({ expression, groupName, args }) => {
+        cst = toLiquidHtmlCST(`{% cycle ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTag');
+        expectPath(cst, '0.name').to.equal('cycle');
+        expectPath(cst, '0.markup.type').to.equal('CycleMarkup');
+        if (groupName) {
+          expectPath(cst, '0.markup.groupName.type').to.equal(groupName.type);
+          expectLocation(cst, '0.markup.groupName');
+        } else {
+          expectPath(cst, '0.markup.groupName').to.equal(null);
+        }
+        expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+        args.forEach((arg, i) => {
+          expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
+          expectLocation(cst, `0.markup.args.${i}`);
+        });
+        expectPath(cst, '0.whitespaceStart').to.equal(null);
+        expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        expectLocation(cst, '0');
+        expectLocation(cst, '0.markup');
+      });
+    });
+
     it('should parse the render tag', () => {
       [
         {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -36,6 +36,7 @@ export enum ConcreteNodeTypes {
   Condition = 'Condition',
 
   AssignMarkup = 'AssignMarkup',
+  CycleMarkup = 'CycleMarkup',
   ForMarkup = 'ForMarkup',
   RenderMarkup = 'RenderMarkup',
   PaginateMarkup = 'PaginateMarkup',
@@ -232,6 +233,7 @@ export type ConcreteLiquidTag =
   | ConcreteLiquidTagBaseCase;
 export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagAssign
+  | ConcreteLiquidTagCycle
   | ConcreteLiquidTagEcho
   | ConcreteLiquidTagElsif
   | ConcreteLiquidTagInclude
@@ -264,6 +266,17 @@ export interface ConcreteLiquidTagAssignMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.AssignMarkup> {
   name: string;
   value: ConcreteLiquidVariable;
+}
+
+export interface ConcreteLiquidTagCycle
+  extends ConcreteLiquidTagNode<
+    NamedTags.cycle,
+    ConcreteLiquidTagCycleMarkup
+  > {}
+export interface ConcreteLiquidTagCycleMarkup
+  extends ConcreteBasicNode<ConcreteNodeTypes.CycleMarkup> {
+  groupName: ConcreteLiquidExpression | null;
+  args: ConcreteLiquidExpression[];
 }
 
 export interface ConcreteLiquidTagRender
@@ -578,8 +591,9 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
 
     liquidTag: 0,
     liquidTagBaseCase: 0,
-    liquidTagEcho: 0,
     liquidTagAssign: 0,
+    liquidTagEcho: 0,
+    liquidTagCycle: 0,
     liquidTagRender: 0,
     liquidTagInclude: 0,
     liquidTagSection: 0,
@@ -607,6 +621,14 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       type: ConcreteNodeTypes.AssignMarkup,
       name: 0,
       value: 4,
+      locStart,
+      locEnd,
+    },
+
+    liquidTagCycleMarkup: {
+      type: ConcreteNodeTypes.CycleMarkup,
+      groupName: 0,
+      args: 3,
       locStart,
       locEnd,
     },

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -92,6 +92,7 @@ function getCssDisplay(
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.CycleMarkup:
     case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
@@ -152,6 +153,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.Range:
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
+    case NodeTypes.CycleMarkup:
     case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -142,6 +142,22 @@ function printNamedLiquidBlock(
       return tag(trailingWhitespace);
     }
 
+    case NamedTags.cycle: {
+      const whitespace = node.markup.args.length > 1 ? line : ' ';
+      return group([
+        '{%',
+        whitespaceStart,
+        ' ',
+        node.name,
+        // We want to break after the groupName
+        node.markup.groupName ? ' ' : '',
+        indent(path.call((p) => print(p), 'markup')),
+        whitespace,
+        whitespaceEnd,
+        '%}',
+      ]);
+    }
+
     case NamedTags.include:
     case NamedTags.render: {
       const markup = node.markup;

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -382,6 +382,25 @@ function printNode(
       return [node.name, ' = ', path.call(print, 'value')];
     }
 
+    case NodeTypes.CycleMarkup: {
+      const doc: Doc[] = [];
+
+      if (node.groupName) {
+        doc.push(path.call(print, 'groupName'), ':');
+      }
+
+      const whitespace = node.args.length > 1 ? line : ' ';
+      doc.push(
+        whitespace,
+        join(
+          [',', whitespace],
+          path.map((p) => print(p), 'args'),
+        ),
+      );
+
+      return doc;
+    }
+
     case NodeTypes.ForMarkup: {
       const doc = [node.variableName, ' in ', path.call(print, 'collection')];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export enum NodeTypes {
   LogicalExpression = 'LogicalExpression',
 
   AssignMarkup = 'AssignMarkup',
+  CycleMarkup = 'CycleMarkup',
   ForMarkup = 'ForMarkup',
   PaginateMarkup = 'PaginateMarkup',
   RenderMarkup = 'RenderMarkup',
@@ -55,6 +56,7 @@ export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
 export enum NamedTags {
   assign = 'assign',
   case = 'case',
+  cycle = 'cycle',
   echo = 'echo',
   elsif = 'elsif',
   form = 'form',

--- a/test/liquid-tag-cycle/fixed.liquid
+++ b/test/liquid-tag-cycle/fixed.liquid
@@ -1,0 +1,20 @@
+It should not break when it only has one arg (weird)
+printWidth: 1
+{% cycle x %}
+{% cycle var: x %}
+
+It should break before the first argument
+printWidth: 1
+{% cycle
+  thing,
+  'string'
+%}
+{% cycle var:
+  thing,
+  'string'
+%}
+
+It should support all types of arguments, and add spaces
+{% cycle x: f, 'string', true %}
+{% cycle 'group': f, 'string' %}
+{% cycle 1: f, 0.0 %}

--- a/test/liquid-tag-cycle/index.liquid
+++ b/test/liquid-tag-cycle/index.liquid
@@ -1,0 +1,14 @@
+It should not break when it only has one arg (weird)
+printWidth: 1
+{% cycle x %}
+{% cycle var:x %}
+
+It should break before the first argument
+printWidth: 1
+{% cycle thing,'string' %}
+{% cycle var:  thing,   'string' %}
+
+It should support all types of arguments, and add spaces
+{% cycle x:f,'string',true %}
+{% cycle "group":f,"string" %}
+{% cycle 1:f,0.0 %}

--- a/test/liquid-tag-cycle/index.spec.ts
+++ b/test/liquid-tag-cycle/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Add support for the `cycle` tag

## Decisions:

- Print `{% cycle` or `{% cycle $groupName:}` on the first line
- Maybe break list of items
- `%}` on new line if broken

## Examples

```liquid
{% # printWidth: 1 %}
{% cycle
  'one',
  'two'
%}

{% # or %}
{% cycle groupName:
  'one',
  'two'
%}
```

Fixes #68
