### PR TITLE
Add support for the `capture` open tag parsing

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -77,6 +77,7 @@ LiquidHTML {
 
   liquidTagOpen =
     | liquidTagOpenCase
+    | liquidTagOpenCapture
     | liquidTagOpenForm
     | liquidTagOpenFor
     | liquidTagOpenTablerow
@@ -116,9 +117,10 @@ LiquidHTML {
   liquidTagCycle = liquidTagRule<"cycle", liquidTagCycleMarkup>
   liquidTagCycleMarkup = (liquidExpression ":")? space* nonemptyListOf<liquidExpression, argumentSeparator> space*
 
-  liquidTagIncrement = liquidTagRule<"increment", liquidTagIncrementMarkup>
-  liquidTagDecrement = liquidTagRule<"decrement", liquidTagIncrementMarkup>
-  liquidTagIncrementMarkup = variableSegmentAsLookup space*
+  liquidTagIncrement = liquidTagRule<"increment", variableSegmentAsLookupMarkup>
+  liquidTagDecrement = liquidTagRule<"decrement", variableSegmentAsLookupMarkup>
+  liquidTagOpenCapture = liquidTagOpenRule<"capture", variableSegmentAsLookupMarkup>
+  variableSegmentAsLookupMarkup = variableSegmentAsLookup space*
 
   liquidTagSection = liquidTagRule<"section", liquidTagSectionMarkup>
   liquidTagSectionMarkup = liquidString space*

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -120,6 +120,7 @@ export type LiquidTag = LiquidTagNamed | LiquidTagBaseCase;
 export type LiquidTagNamed =
   | LiquidTagAssign
   | LiquidTagCase
+  | LiquidTagCapture
   | LiquidTagCycle
   | LiquidTagDecrement
   | LiquidTagEcho
@@ -170,6 +171,9 @@ export interface LiquidTagIncrement
   extends LiquidTagNode<NamedTags.increment, LiquidVariableLookup> {}
 export interface LiquidTagDecrement
   extends LiquidTagNode<NamedTags.decrement, LiquidVariableLookup> {}
+
+export interface LiquidTagCapture
+  extends LiquidTagNode<NamedTags.capture, LiquidVariableLookup> {}
 
 export interface LiquidTagCycle
   extends LiquidTagNode<NamedTags.cycle, CycleMarkup> {}
@@ -852,6 +856,15 @@ function toNamedLiquidTag(
         ...liquidTagBaseAttributes(node, source),
         name: node.name,
         markup: toExpression(node.markup, source) as LiquidVariableLookup,
+      };
+    }
+
+    case NamedTags.capture: {
+      return {
+        ...liquidTagBaseAttributes(node, source),
+        name: node.name,
+        markup: toExpression(node.markup, source) as LiquidVariableLookup,
+        children: [],
       };
     }
 

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -689,6 +689,17 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should parse capture arguments as a singular liquid variable lookup', () => {
+      [{ expression: `var`, type: 'VariableLookup' }].forEach(({ expression, type }) => {
+        cst = toLiquidHtmlCST(`{% capture ${expression} -%}`);
+        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+        expectPath(cst, '0.name').to.equal('capture');
+        expectPath(cst, '0.markup.type').to.equal(type);
+        expectLocation(cst, '0');
+        expectLocation(cst, '0.markup');
+      });
+    });
+
     it('should parse when arguments as an array of liquid expressions', () => {
       [
         { expression: `"string"`, args: [{ type: 'String' }] },

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -144,6 +144,7 @@ export type ConcreteLiquidTagOpen =
   | ConcreteLiquidTagOpenNamed;
 export type ConcreteLiquidTagOpenNamed =
   | ConcreteLiquidTagOpenCase
+  | ConcreteLiquidTagOpenCapture
   | ConcreteLiquidTagOpenIf
   | ConcreteLiquidTagOpenUnless
   | ConcreteLiquidTagOpenForm
@@ -159,6 +160,12 @@ export interface ConcreteLiquidTagOpenNode<Name, Markup>
 
 export interface ConcreteLiquidTagOpenBaseCase
   extends ConcreteLiquidTagOpenNode<string, string> {}
+
+export interface ConcreteLiquidTagOpenCapture
+  extends ConcreteLiquidTagOpenNode<
+    NamedTags.capture,
+    ConcreteLiquidVariableLookup
+  > {}
 
 export interface ConcreteLiquidTagOpenCase
   extends ConcreteLiquidTagOpenNode<NamedTags.case, ConcreteLiquidExpression> {}
@@ -546,6 +553,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locEnd,
     },
 
+    liquidTagOpenCapture: 0,
     liquidTagOpenForm: 0,
     liquidTagOpenFormMarkup: 0,
     liquidTagOpenFor: 0,
@@ -629,7 +637,6 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locEnd,
     },
     liquidTagEchoMarkup: 0,
-    liquidTagIncrementMarkup: 0,
     liquidTagSectionMarkup: 0,
     liquidTagLayoutMarkup: 0,
     liquidTagAssignMarkup: {
@@ -767,6 +774,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       locStart,
       locEnd,
     },
+    variableSegmentAsLookupMarkup: 0,
     variableSegmentAsLookup: {
       type: ConcreteNodeTypes.VariableLookup,
       name: 0,

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -168,6 +168,7 @@ function printNamedLiquidBlock(
       return tag(trailingWhitespace);
     }
 
+    case NamedTags.capture:
     case NamedTags.increment:
     case NamedTags.decrement:
     case NamedTags.layout:

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export function isLiquidHtmlNode(value: any): value is LiquidHtmlNode {
 // These are officially supported with special node types
 export enum NamedTags {
   assign = 'assign',
+  capture = 'capture',
   case = 'case',
   cycle = 'cycle',
   decrement = 'decrement',

--- a/test/liquid-tag-capture/fixed.liquid
+++ b/test/liquid-tag-capture/fixed.liquid
@@ -1,0 +1,6 @@
+It should never break on capture var name
+printWidth: 1
+{% capture varName -%}{%- endcapture %}
+{% capture varName -%}{%- endcapture %}
+{% capture varName -%}{%- endcapture %}
+{%- capture varName -%}{% endcapture %}

--- a/test/liquid-tag-capture/index.liquid
+++ b/test/liquid-tag-capture/index.liquid
@@ -1,0 +1,8 @@
+It should never break on capture var name
+printWidth: 1
+{% capture varName %}{% endcapture %}
+{%   capture   varName   %}{% endcapture %}
+{%capture varName %}{% endcapture %}
+{%- capture
+varName
+-%}{% endcapture %}

--- a/test/liquid-tag-capture/index.spec.ts
+++ b/test/liquid-tag-capture/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
This does not fixes the capture body issue. It looks like that's broken
but I'll fix it in a different PR and handle it the same way I'd handle
`raw` I think.

As for the tag name markup, rule is simple: don't break it.

Fixes #67
