### PR TITLE
Add support for `{% # prettier-ignore %}`

### DIFF
--- a/src/printer/utils/node.ts
+++ b/src/printer/utils/node.ts
@@ -118,12 +118,31 @@ export function shouldPreserveContent(
   return false;
 }
 
-export function isPrettierIgnoreNode(node: LiquidHtmlNode | undefined) {
+export function isPrettierIgnoreHtmlNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment {
   return (
-    node &&
+    !!node &&
     node.type === NodeTypes.HtmlComment &&
     /^\s*prettier-ignore/m.test(node.body)
   );
+}
+
+export function isPrettierIgnoreLiquidNode(
+  node: LiquidHtmlNode | undefined,
+): node is LiquidTag {
+  return (
+    !!node &&
+    node.type === NodeTypes.LiquidTag &&
+    node.name === '#' &&
+    /^\s*prettier-ignore/m.test(node.markup)
+  );
+}
+
+export function isPrettierIgnoreNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment | LiquidTag {
+  return isPrettierIgnoreLiquidNode(node) || isPrettierIgnoreHtmlNode(node);
 }
 
 export function hasPrettierIgnore(node: LiquidHtmlNode) {

--- a/test/liquid-prettier-ignore/fixed.liquid
+++ b/test/liquid-prettier-ignore/fixed.liquid
@@ -1,0 +1,19 @@
+It should respect the html prettier ignore comment
+printWidth: 1
+<!-- prettier-ignore -->
+{% cycle a,b,c %}
+
+It should respect the html prettier ignore comment on tags
+printWidth: 1
+<a>
+  <!-- prettier-ignore -->
+  <b>{% cycle a,b,c %}</b
+  >hi
+</a>
+
+It should respect the html prettier ignore comment on liquid tags
+printWidth: 1
+<a>
+  <!-- prettier-ignore -->
+  {%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>

--- a/test/liquid-prettier-ignore/fixed.liquid
+++ b/test/liquid-prettier-ignore/fixed.liquid
@@ -1,9 +1,9 @@
-It should respect the html prettier ignore comment
+It should respect the html prettier-ignore comment
 printWidth: 1
 <!-- prettier-ignore -->
 {% cycle a,b,c %}
 
-It should respect the html prettier ignore comment on tags
+It should respect the html prettier-ignore comment on tags
 printWidth: 1
 <a>
   <!-- prettier-ignore -->
@@ -11,9 +11,37 @@ printWidth: 1
   >hi
 </a>
 
-It should respect the html prettier ignore comment on liquid tags
+It should respect the html prettier-ignore comment on liquid tags
 printWidth: 1
 <a>
   <!-- prettier-ignore -->
   {%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>
+
+It should respect the liquid prettier-ignore comment
+printWidth: 1
+{% # prettier-ignore %}
+{% cycle a,b,c %}
+
+It should respect the liquid prettier-ignore comment on tags
+printWidth: 1
+<a>
+  {% # prettier-ignore %}
+  <b>{% cycle a,b,c %}</b
+  >hi
+</a>
+
+It should respect the liquid prettier-ignore comment on liquid tags
+printWidth: 1
+<a>
+  {% # prettier-ignore %}
+  {%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>
+
+It should respect the liquid prettier-ignore comment on tags (and maintain whitespace semantic meaning)
+printWidth: 1
+<a>
+  {% # prettier-ignore %}
+  {%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+  {{- 'hi' }}
 </a>

--- a/test/liquid-prettier-ignore/index.liquid
+++ b/test/liquid-prettier-ignore/index.liquid
@@ -1,18 +1,44 @@
-It should respect the html prettier ignore comment
+It should respect the html prettier-ignore comment
 printWidth: 1
 <!-- prettier-ignore -->
 {% cycle a,b,c %}
 
-It should respect the html prettier ignore comment on tags
+It should respect the html prettier-ignore comment on tags
 printWidth: 1
 <a>
 <!-- prettier-ignore -->
 <b>{% cycle a,b,c %}</b>hi
 </a>
 
-It should respect the html prettier ignore comment on liquid tags
+It should respect the html prettier-ignore comment on liquid tags
 printWidth: 1
 <a>
 <!-- prettier-ignore -->
 {%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>
+
+It should respect the liquid prettier-ignore comment
+printWidth: 1
+{% # prettier-ignore %}
+{% cycle a,b,c %}
+
+It should respect the liquid prettier-ignore comment on tags
+printWidth: 1
+<a>
+{% # prettier-ignore %}
+<b>{% cycle a,b,c %}</b>hi
+</a>
+
+It should respect the liquid prettier-ignore comment on liquid tags
+printWidth: 1
+<a>
+{% # prettier-ignore %}
+{%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>
+
+It should respect the liquid prettier-ignore comment on tags (and maintain whitespace semantic meaning)
+printWidth: 1
+<a>
+{% # prettier-ignore %}
+{%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}{{ 'hi' }}
 </a>

--- a/test/liquid-prettier-ignore/index.liquid
+++ b/test/liquid-prettier-ignore/index.liquid
@@ -1,0 +1,18 @@
+It should respect the html prettier ignore comment
+printWidth: 1
+<!-- prettier-ignore -->
+{% cycle a,b,c %}
+
+It should respect the html prettier ignore comment on tags
+printWidth: 1
+<a>
+<!-- prettier-ignore -->
+<b>{% cycle a,b,c %}</b>hi
+</a>
+
+It should respect the html prettier ignore comment on liquid tags
+printWidth: 1
+<a>
+<!-- prettier-ignore -->
+{%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+</a>

--- a/test/liquid-prettier-ignore/index.spec.ts
+++ b/test/liquid-prettier-ignore/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -56,6 +56,7 @@ export function assertFormattedEqualsFixed(
       let expected = expectedChunks[i].replace(TEST_MESSAGE, '').trimStart();
 
       if (TEST_IDEMPOTENCE) {
+        if (testConfig.debug) debug(actual, testOptions);
         actual = format(actual, testOptions).trimEnd();
       }
 


### PR DESCRIPTION
Turns out we already support #47

Fixes #47
