### PR TITLE
Fix unnecessary whitespace stripping on liquid html attribute break

### DIFF
--- a/src/printer/preprocess/augment-with-whitespace-helpers.ts
+++ b/src/printer/preprocess/augment-with-whitespace-helpers.ts
@@ -14,7 +14,12 @@ import {
   WithWhitespaceHelpers,
 } from '~/types';
 import { isBranchedTag } from '~/parser';
-import { isPreLikeNode, isScriptLikeTag, isWhitespace } from '~/printer/utils';
+import {
+  isAttributeNode,
+  isPreLikeNode,
+  isScriptLikeTag,
+  isWhitespace,
+} from '~/printer/utils';
 
 type RequiredAugmentations = WithParent &
   WithSiblings &
@@ -256,6 +261,7 @@ function isTrailingWhitespaceSensitiveNode(node: AugmentedAstNode): boolean {
       || isScriptLikeTag(node.parentNode) // technically we don't use this one.
       || !isInnerRightWhitespaceSensitiveCssDisplay(node.parentNode.cssDisplay)
       || isTrimmingInnerRight(node.parentNode)
+      || isAttributeNode(node as any)
     )
   ) {
     return false;

--- a/src/printer/print/element.ts
+++ b/src/printer/print/element.ts
@@ -35,11 +35,15 @@ export function printElement(
   print: LiquidPrinter,
 ) {
   const node = path.getValue();
+  const attrGroupId = Symbol('element-attr-group-id');
+  const elementGroupId = Symbol('element-group-id');
 
   if (hasNoCloseMarker(node)) {
     // TODO, broken for HtmlComment but this code path is not used (so far).
     return [
-      group(printOpeningTag(path, options, print)),
+      group(printOpeningTag(path, options, print, attrGroupId), {
+        id: attrGroupId,
+      }),
       ...printClosingTag(node, options),
       printClosingTagSuffix(node, options),
     ];
@@ -51,20 +55,21 @@ export function printElement(
   ) {
     return [
       printOpeningTagPrefix(node, options),
-      group(printOpeningTag(path, options, print)),
+      group(printOpeningTag(path, options, print, attrGroupId), {
+        id: attrGroupId,
+      }),
       ...replaceTextEndOfLine(getNodeContent(node, options)),
       ...printClosingTag(node, options),
       printClosingTagSuffix(node, options),
     ];
   }
 
-  const attrGroupId = Symbol('element-attr-group-id');
-  const elementGroupId = Symbol('element-group-id');
-
   const printTag = (doc: Doc) =>
     group(
       [
-        group(printOpeningTag(path, options, print), { id: attrGroupId }),
+        group(printOpeningTag(path, options, print, attrGroupId), {
+          id: attrGroupId,
+        }),
         doc,
         printClosingTag(node, options),
       ],

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -24,13 +24,12 @@ import {
   hasMeaningfulLackOfDanglingWhitespace,
   isDeeplyNested,
   isEmpty,
-  isHtmlNode,
   markupLines,
   originallyHadLineBreaks,
   reindent,
   trim,
-  bodyLines,
   hasLineBreakInRange,
+  isAttributeNode,
 } from '~/printer/utils';
 
 import { printChildren } from '~/printer/print/children';
@@ -39,7 +38,6 @@ const LIQUID_TAGS_THAT_ALWAYS_BREAK = ['for', 'case'];
 
 const { builders, utils } = doc;
 const { group, hardline, ifBreak, indent, join, line, softline } = builders;
-const { replaceTextEndOfLine } = utils as any;
 
 export function printLiquidDrop(
   path: LiquidAstPath,
@@ -503,13 +501,6 @@ export function printLiquidRawTag(
   }
 
   return [blockStart, ...body, blockEnd];
-}
-
-function isAttributeNode(node: LiquidTag) {
-  return (
-    isHtmlNode(node.parentNode) &&
-    node.parentNode.attributes.indexOf(node) !== -1
-  );
 }
 
 function innerLeadingWhitespace(node: LiquidTag | LiquidBranch) {

--- a/src/printer/print/tag.ts
+++ b/src/printer/print/tag.ts
@@ -273,6 +273,7 @@ function printAttributes(
   path: AstPath<HtmlNode>,
   options: LiquidParserOptions,
   print: LiquidPrinter,
+  attrGroupId: symbol,
 ) {
   const node = path.getValue();
   const { locStart, locEnd } = options;
@@ -307,7 +308,7 @@ function printAttributes(
       ? replaceTextEndOfLine(
           options.originalText.slice(locStart(attribute), locEnd(attribute)),
         )
-      : print(attributePath);
+      : print(attributePath, { trailingSpaceGroupId: attrGroupId });
   }, 'attributes');
 
   const forceNotToBreakAttrContent =
@@ -319,7 +320,7 @@ function printAttributes(
       (isHtmlElement(node) && node.children.length > 0)) &&
       node.attributes &&
       node.attributes.length === 1 &&
-      !isMultilineLiquidTag(node.attributes[0]));
+      !isLiquidNode(node.attributes[0]));
 
   const forceBreakAttrContent =
     node.source
@@ -386,12 +387,13 @@ export function printOpeningTag(
   path: AstPath<HtmlNode>,
   options: LiquidParserOptions,
   print: LiquidPrinter,
+  attrGroupId: symbol,
 ) {
   const node = path.getValue();
 
   return [
     printOpeningTagStart(node, options),
-    printAttributes(path, options, print),
+    printAttributes(path, options, print, attrGroupId),
     hasNoCloseMarker(node) ? '' : printOpeningTagEnd(node),
   ];
 }

--- a/src/printer/utils/node.ts
+++ b/src/printer/utils/node.ts
@@ -12,6 +12,7 @@ import {
   HtmlComment,
   HtmlElement,
   LiquidTag,
+  AttributeNode,
 } from '~/types';
 import { isEmpty } from '~/printer/utils/array';
 
@@ -74,6 +75,15 @@ export function isMultilineLiquidTag(
 
 export function isHtmlNode(node: LiquidHtmlNode | undefined): node is HtmlNode {
   return !!node && HtmlNodeTypes.includes(node.type as any);
+}
+
+export function isAttributeNode(
+  node: LiquidHtmlNode,
+): node is AttributeNode & { parentNode: HtmlNode } {
+  return (
+    isHtmlNode(node.parentNode) &&
+    node.parentNode.attributes.indexOf(node as AttributeNode) !== -1
+  );
 }
 
 export function hasNonTextChild(node: LiquidHtmlNode) {

--- a/test/issue-99/fixed.liquid
+++ b/test/issue-99/fixed.liquid
@@ -1,0 +1,23 @@
+It should not consider the trailing whitespace of the last attribute to be sensitive
+printWidth: 1
+<ul
+  {% render 'hi',
+    arg: 1
+  %}
+></ul>
+<img
+  {% render 'hi',
+    arg: 1
+  %}
+>
+<self-closing
+  {% render 'hi',
+    arg: 1
+  %}
+/>
+
+It should not change the whitespace stripping when it doesn't break
+pritnWidth: 1000
+<ul {% render 'hi', arg: 1 %}></ul>
+<img {% render 'hi', arg: 1 %}>
+<self-closing {% render 'hi', arg: 1 %} />

--- a/test/issue-99/index.liquid
+++ b/test/issue-99/index.liquid
@@ -1,0 +1,11 @@
+It should not consider the trailing whitespace of the last attribute to be sensitive
+printWidth: 1
+<ul {% render 'hi', arg: 1 %}></ul>
+<img {% render 'hi', arg: 1 %}>
+<self-closing {% render 'hi', arg: 1 %}/>
+
+It should not change the whitespace stripping when it doesn't break
+pritnWidth: 1000
+<ul {% render 'hi', arg: 1 %}></ul>
+<img {% render 'hi', arg: 1 %}>
+<self-closing {% render 'hi', arg: 1 %}/>

--- a/test/issue-99/index.spec.ts
+++ b/test/issue-99/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
Fixes #99

Input:
```liquid
It should not consider the trailing whitespace of the last attribute to be sensitive
printWidth: 1
<ul {% render 'hi', arg: 1 %}></ul>
<img {% render 'hi', arg: 1 %}>
<self-closing {% render 'hi', arg: 1 %}/>
```

Output:
```liquid
It should not consider the trailing whitespace of the last attribute to be sensitive
printWidth: 1
<ul
  {% render 'hi',
    arg: 1
  %}
></ul>
<img
  {% render 'hi',
    arg: 1
  %}
>
<self-closing
  {% render 'hi',
    arg: 1
  %}
/>
```
