### PR TITLE
Add proper support for HTML doctypes

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -317,12 +317,19 @@ LiquidHTML <: Liquid {
     "---" newline anyExceptStar<"---"> "---" newline
 
   HtmlNode =
+    | HtmlDoctype
     | HtmlComment
     | HtmlRawTag
     | HtmlVoidElement
     | HtmlSelfClosingElement
     | HtmlTagClose
     | HtmlTagOpen
+
+  // https://html.spec.whatwg.org/multipage/syntax.html#the-doctype
+  HtmlDoctype =
+    #("<!" caseInsensitive<"doctype"> space+ caseInsensitive<"html">) legacyDoctypeString? ">"
+  legacyDoctypeString
+    = anyExceptPlus<">">
 
   HtmlComment = "<!--" #(anyExceptStar<"-->"> "-->")
 
@@ -381,10 +388,8 @@ LiquidHTML <: Liquid {
   quotes =  "'" | "\""
 
   // https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
-  // Cheating a bit with by stretching it to the doctype
   voidElementName =
-    ( caseInsensitive<"!doctype">
-    | caseInsensitive<"area">
+    ( caseInsensitive<"area">
     | caseInsensitive<"base">
     | caseInsensitive<"br">
     | caseInsensitive<"col">

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -55,6 +55,7 @@ export type LiquidHtmlNode =
   | DocumentNode
   | YAMLFrontmatter
   | LiquidNode
+  | HtmlDoctype
   | HtmlNode
   | AttributeNode
   | LiquidVariable
@@ -392,6 +393,10 @@ export interface RawMarkup extends ASTNode<NodeTypes.RawMarkup> {
   value: string;
 }
 
+export interface HtmlDoctype extends ASTNode<NodeTypes.HtmlDoctype> {
+  legacyDoctypeString: string | null;
+}
+
 export interface HtmlComment extends ASTNode<NodeTypes.HtmlComment> {
   body: string;
 }
@@ -659,6 +664,16 @@ export function cstToAst(
 
       case ConcreteNodeTypes.HtmlSelfClosingElement: {
         builder.push(toHtmlSelfClosingElement(node, source));
+        break;
+      }
+
+      case ConcreteNodeTypes.HtmlDoctype: {
+        builder.push({
+          type: NodeTypes.HtmlDoctype,
+          legacyDoctypeString: node.legacyDoctypeString,
+          position: position(node),
+          source,
+        });
         break;
       }
 

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -7,6 +7,25 @@ import { deepGet } from '~/utils';
 describe('Unit: toLiquidHtmlCST(text)', () => {
   let cst: LiquidHtmlCST;
 
+  describe('Case: HtmlDoctype', () => {
+    it('should basically parse html doctypes', () => {
+      [
+        { text: '<!doctype html>', legacyDoctypeString: null },
+        { text: '<!doctype html >', legacyDoctypeString: null },
+        {
+          text: `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+           "http://www.w3.org/TR/html4/frameset.dtd">`,
+          legacyDoctypeString: `PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+           "http://www.w3.org/TR/html4/frameset.dtd"`,
+        },
+      ].forEach(({ text, legacyDoctypeString }) => {
+        cst = toLiquidHtmlCST(text);
+        expectPath(cst, '0.type').to.equal('HtmlDoctype');
+        expectPath(cst, '0.legacyDoctypeString').to.equal(legacyDoctypeString);
+      });
+    });
+  });
+
   describe('Case: HtmlComment', () => {
     it('should basically parse html comments', () => {
       ['<!-- hello world -->'].forEach((text) => {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -6,6 +6,7 @@ import { LiquidHTMLCSTParsingError } from '~/parser/errors';
 import { Comparators, NamedTags } from '~/types';
 
 export enum ConcreteNodeTypes {
+  HtmlDoctype = 'HtmlDoctype',
   HtmlComment = 'HtmlComment',
   HtmlRawTag = 'HtmlRawTag',
   HtmlVoidElement = 'HtmlVoidElement',
@@ -65,6 +66,11 @@ export interface ConcreteBasicNode<T> {
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
   name: string | ConcreteLiquidDrop;
   attrList?: ConcreteAttributeNode[];
+}
+
+export interface ConcreteHtmlDoctype
+  extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlDoctype> {
+  legacyDoctypeString: string | null;
 }
 
 export interface ConcreteHtmlComment
@@ -401,6 +407,7 @@ export interface ConcreteLiquidVariableLookup
 }
 
 export type ConcreteHtmlNode =
+  | ConcreteHtmlDoctype
   | ConcreteHtmlComment
   | ConcreteHtmlRawTag
   | ConcreteHtmlVoidElement
@@ -903,6 +910,13 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     yamlFrontmatter: {
       type: ConcreteNodeTypes.YAMLFrontmatter,
       body: 2,
+      locStart,
+      locEnd,
+    },
+
+    HtmlDoctype: {
+      type: ConcreteNodeTypes.HtmlDoctype,
+      legacyDoctypeString: 4,
       locStart,
       locEnd,
     },

--- a/src/printer/preprocess/augment-with-css-properties.ts
+++ b/src/printer/preprocess/augment-with-css-properties.ts
@@ -75,6 +75,7 @@ function getCssDisplay(
     case NodeTypes.AttrEmpty:
       return 'inline';
 
+    case NodeTypes.HtmlDoctype:
     case NodeTypes.HtmlComment:
       return 'block';
 
@@ -140,6 +141,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
     case NodeTypes.AttrEmpty:
       return CSS_WHITE_SPACE_DEFAULT;
 
+    case NodeTypes.HtmlDoctype:
     case NodeTypes.HtmlComment:
       return CSS_WHITE_SPACE_DEFAULT;
 

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -308,6 +308,11 @@ function printNode(
       );
     }
 
+    case NodeTypes.HtmlDoctype: {
+      if (!node.legacyDoctypeString) return '<!doctype html>';
+      return node.source.slice(node.position.start, node.position.end);
+    }
+
     case NodeTypes.HtmlComment: {
       return [
         '<!--',

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export enum NodeTypes {
   LiquidDrop = 'LiquidDrop',
   HtmlSelfClosingElement = 'HtmlSelfClosingElement',
   HtmlVoidElement = 'HtmlVoidElement',
+  HtmlDoctype = 'HtmlDoctype',
   HtmlComment = 'HtmlComment',
   HtmlElement = 'HtmlElement',
   HtmlRawNode = 'HtmlRawNode',
@@ -220,6 +221,7 @@ export type HtmlSelfClosingElement = Augmented<
   AllAugmentations
 >;
 export type HtmlRawNode = Augmented<AST.HtmlRawNode, AllAugmentations>;
+export type HtmlDoctype = Augmented<AST.HtmlDoctype, AllAugmentations>;
 export type HtmlComment = Augmented<AST.HtmlComment, AllAugmentations>;
 export type AttributeNode = Augmented<AST.AttributeNode, AllAugmentations>;
 export type AttrSingleQuoted = Augmented<

--- a/test/html-doctype/fixed.liquid
+++ b/test/html-doctype/fixed.liquid
@@ -1,0 +1,11 @@
+It supports html5 doctypes
+<!doctype html>
+<!doctype html>
+
+It supports older doctypes
+<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html PUBLIC
+  "-//W3C//DTD XHTML 1.1//EN"
+  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">

--- a/test/html-doctype/index.liquid
+++ b/test/html-doctype/index.liquid
@@ -1,0 +1,11 @@
+It supports html5 doctypes
+<!DOCTYPE HTML>
+<!doctype html>
+
+It supports older doctypes
+<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html PUBLIC
+  "-//W3C//DTD XHTML 1.1//EN"
+  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">

--- a/test/html-doctype/index.spec.ts
+++ b/test/html-doctype/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
For html5 doctypes, prefer the lowercase version. For other versions, we'll just paste the source as is.

Fixes #96
