### PR TITLE
Add support for nested block comments

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -32,6 +32,7 @@ Liquid <: Helpers {
   openControl := "{{" | "{%"
 
   liquidNode =
+    | liquidBlockComment
     | liquidRawTag
     | liquidDrop
     | liquidTagClose
@@ -163,7 +164,6 @@ Liquid <: Helpers {
 
   liquidRawTag =
     | liquidRawTagImpl<"raw">
-    | liquidRawTagImpl<"comment">
     | liquidRawTagImpl<"javascript">
     | liquidRawTagImpl<"schema">
     | liquidRawTagImpl<"style">
@@ -173,6 +173,13 @@ Liquid <: Helpers {
     "{%" "-"? space* "end" name space* "-"? "%}"
   liquidRawTagClose<name> =
     "{%" "-"? space* "end" name space* "-"? "%}"
+
+  liquidBlockComment =
+    commentBlockStart
+      (liquidBlockComment | anyExceptPlus<(commentBlockStart | commentBlockEnd)>)*
+    commentBlockEnd
+  commentBlockStart = "{%" "-"? space* ("comment"    ~identifierCharacter) space* tagMarkup "-"? "%}"
+  commentBlockEnd   = "{%" "-"? space* ("endcomment" ~identifierCharacter) space* tagMarkup "-"? "%}"
 
   // In order for the grammar to "fallback" to the base case, this
   // rule must pass if and only if we support what we parse. This
@@ -275,6 +282,7 @@ LiquidStatement <: Liquid {
   space := " " | "\t"
 
   LiquidStatement =
+    | liquidBlockComment
     | liquidRawTag
     | liquidTagClose
     | liquidTagOpen
@@ -297,6 +305,24 @@ LiquidStatement <: Liquid {
 
   liquidRawTagClose<name>
     := "end" name space* &liquidStatementEnd
+
+  liquidBlockComment :=
+    commentBlockStart statementSep
+      (listOf<liquidCommentBlockStatement, statementSep> statementSep)?
+    commentBlockEnd
+
+  liquidCommentBlockStatement =
+    | liquidBlockComment
+    | nonTerminalCommentLine
+
+  commentBlockStart
+    := ("comment" ~identifierCharacter) space* tagMarkup
+
+  commentBlockEnd
+    := ("endcomment" ~identifierCharacter) space* tagMarkup
+
+  nonTerminalCommentLine
+    = ~commentBlockEnd anyExceptPlus<newline>
 
   liquidInlineComment
     := "#" space? tagMarkup &liquidStatementEnd

--- a/src/parser/cst.spec.ts
+++ b/src/parser/cst.spec.ts
@@ -432,6 +432,43 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       });
     });
 
+    it('should support nested comments', () => {
+      const commentBodyContainingNestedComment = `  hello
+      comment tagMarkup
+        nested comment body
+      endcomment
+      outer comment body`;
+      const statementSep = '\n  ';
+      const commentExpr = ['comment', commentBodyContainingNestedComment, 'endcomment'].join(
+        statementSep,
+      );
+      const testStr = ['{% liquid', commentExpr, '%}'].join('\n');
+      cst = toLiquidHtmlCST(testStr);
+      expectPath(cst, '0.type').to.equal('LiquidTag');
+      expectPath(cst, '0.name').to.equal('liquid');
+      expectPath(cst, '0.markup.0.type').to.equal('LiquidRawTag');
+      expectPath(cst, '0.markup.0.name').to.equal('comment');
+      expectPath(cst, '0.markup.0.body').to.equal(
+        // We don't want the newline but we do want the leading spaces
+        // The reason we want that is because we want this to behave like LiquidRawTag
+        statementSep.slice(1) + commentBodyContainingNestedComment + statementSep,
+      );
+      expectPath(cst, '0.markup.0.whitespaceStart').to.equal('');
+      expectPath(cst, '0.markup.0.whitespaceEnd').to.equal('');
+      expectPath(cst, '0.markup.0.delimiterWhitespaceStart').to.equal('');
+      expectPath(cst, '0.markup.0.delimiterWhitespaceEnd').to.equal('');
+
+      const liquidStatementOffset = '{% liquid\n'.length;
+      expectPath(cst, '0.markup.0.blockStartLocStart').to.equal(liquidStatementOffset);
+      expectPath(cst, '0.markup.0.blockStartLocEnd').to.equal(
+        liquidStatementOffset + 'comment'.length,
+      );
+      expectPath(cst, '0.markup.0.blockEndLocStart').to.equal(
+        testStr.length - 'endcomment\n%}'.length,
+      );
+      expectPath(cst, '0.markup.0.blockEndLocEnd').to.equal(testStr.length - '\n%}'.length);
+    });
+
     it('should parse the echo tag as variables', () => {
       [
         { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
@@ -849,6 +886,22 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       expectPath(cst, '2.name').to.equal('if');
       expectPath(cst, '2.whitespaceStart').to.equal('-');
       expectPath(cst, '2.whitespaceEnd').to.equal(null);
+    });
+
+    it('should support nested comments', () => {
+      const testStr = '{% comment -%} ho {% comment %} ho {% endcomment %} ho {%- endcomment %}';
+      cst = toLiquidHtmlCST(testStr);
+      expectPath(cst, '0.type').to.equal('LiquidRawTag');
+      expectPath(cst, '0.name').to.equal('comment');
+      expectPath(cst, '0.body').to.equal(' ho {% comment %} ho {% endcomment %} ho ');
+      expectPath(cst, '0.whitespaceStart').to.equal('');
+      expectPath(cst, '0.whitespaceEnd').to.equal('-');
+      expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
+      expectPath(cst, '0.delimiterWhitespaceEnd').to.equal('');
+      expectPath(cst, '0.blockStartLocStart').to.equal(0);
+      expectPath(cst, '0.blockStartLocEnd').to.equal(0 + '{% comment -%}'.length);
+      expectPath(cst, '0.blockEndLocStart').to.equal(testStr.length - '{%- endcomment %}'.length);
+      expectPath(cst, '0.blockEndLocEnd').to.equal(testStr.length);
     });
 
     it('should parse tag open / close', () => {

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -515,6 +515,23 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       blockEndLocStart: (tokens: Node[]) => tokens[9].source.startIdx,
       blockEndLocEnd: (tokens: Node[]) => tokens[16].source.endIdx,
     },
+    liquidBlockComment: {
+      type: ConcreteNodeTypes.LiquidRawTag,
+      name: 'comment',
+      body: (tokens: Node[]) => tokens[1].sourceString,
+      whitespaceStart: (tokens: Node[]) => tokens[0].children[1].sourceString,
+      whitespaceEnd: (tokens: Node[]) => tokens[0].children[6].sourceString,
+      delimiterWhitespaceStart: (tokens: Node[]) =>
+        tokens[2].children[1].sourceString,
+      delimiterWhitespaceEnd: (tokens: Node[]) =>
+        tokens[2].children[6].sourceString,
+      locStart,
+      locEnd,
+      blockStartLocStart: (tokens: Node[]) => tokens[0].source.startIdx,
+      blockStartLocEnd: (tokens: Node[]) => tokens[0].source.endIdx,
+      blockEndLocStart: (tokens: Node[]) => tokens[2].source.startIdx,
+      blockEndLocEnd: (tokens: Node[]) => tokens[2].source.endIdx,
+    },
     liquidInlineComment: {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
@@ -876,6 +893,33 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
         liquidStatementOffset + tokens[5].source.startIdx,
       blockEndLocEnd: (tokens: Node[]) =>
         liquidStatementOffset + tokens[5].source.endIdx,
+    },
+
+    liquidBlockComment: {
+      type: ConcreteNodeTypes.LiquidRawTag,
+      name: 'comment',
+      body: (tokens: Node[]) =>
+        // We want this to behave like LiquidRawTag, so we have to do some
+        // shenanigans to make it behave the same while also supporting
+        // nested comments
+        //
+        // We're stripping the newline from the statementSep, that's why we
+        // slice(1). Since statementSep = newline (space | newline)*
+        tokens[1].sourceString.slice(1) + tokens[2].sourceString,
+      whitespaceStart: '',
+      whitespaceEnd: '',
+      delimiterWhitespaceStart: '',
+      delimiterWhitespaceEnd: '',
+      locStart,
+      locEnd,
+      blockStartLocStart: (tokens: Node[]) =>
+        liquidStatementOffset + tokens[0].source.startIdx,
+      blockStartLocEnd: (tokens: Node[]) =>
+        liquidStatementOffset + tokens[0].source.endIdx,
+      blockEndLocStart: (tokens: Node[]) =>
+        liquidStatementOffset + tokens[4].source.startIdx,
+      blockEndLocEnd: (tokens: Node[]) =>
+        liquidStatementOffset + tokens[4].source.endIdx,
     },
 
     liquidInlineComment: {

--- a/test/liquid-comment/fixed.liquid
+++ b/test/liquid-comment/fixed.liquid
@@ -6,6 +6,29 @@
 
 {% comment %}theme-check-disable foo{% endcomment %}
 
+It should support nested comments
+{% comment %}
+  ho
+  {% comment %}
+    hi
+  {% endcomment %}
+  ha
+{% endcomment %}
+
+It should support empty comments
+{% comment %}{% endcomment %}
+
+It should support nested empty comments
+{% comment %}{% comment %}{% endcomment %}{% endcomment %}
+
+It should support nested empty comments (pt 2)
+{% comment %}
+  hi
+  {% comment %}
+  {% endcomment %}
+  ho
+{% endcomment %}
+
 It should support inline comments
 {% # hello world %}
 

--- a/test/liquid-comment/index.liquid
+++ b/test/liquid-comment/index.liquid
@@ -6,6 +6,29 @@ So stuff can be unclosed and it'll be fine.
 
 {% comment %}theme-check-disable foo{% endcomment %}
 
+It should support nested comments
+{%comment%}
+ho
+{% comment %}
+  hi
+{% endcomment %}
+ha
+{%endcomment%}
+
+It should support empty comments
+{% comment %}{% endcomment %}
+
+It should support nested empty comments
+{% comment %}{% comment %}{% endcomment %}{% endcomment %}
+
+It should support nested empty comments (pt 2)
+{% comment %}
+hi
+{% comment %}
+{% endcomment %}
+ho
+{% endcomment %}
+
 It should support inline comments
 {% # hello world %}
 

--- a/test/liquid-liquid-tag/fixed.liquid
+++ b/test/liquid-liquid-tag/fixed.liquid
@@ -33,6 +33,25 @@ It should handle comments correctly
   endcomment
 -%}
 
+It should handle nested comments correctly
+{%- liquid
+  comment
+    how u doin?
+    comment
+      ho
+    endcomment
+  endcomment
+-%}
+
+It should handle empty nested comments correctly
+{%- liquid
+  comment
+    how u doin?
+    comment
+    endcomment
+  endcomment
+-%}
+
 It should handle inline comments correctly
 {%- liquid
   # heyy how u doin

--- a/test/liquid-liquid-tag/index.liquid
+++ b/test/liquid-liquid-tag/index.liquid
@@ -32,6 +32,23 @@ comment
 how u doin?
 endcomment -%}
 
+It should handle nested comments correctly
+{%- liquid
+comment
+how u doin?
+comment
+  ho
+endcomment
+endcomment -%}
+
+It should handle empty nested comments correctly
+{%- liquid
+comment
+how u doin?
+comment
+endcomment
+endcomment -%}
+
 It should handle inline comments correctly
 {%- liquid
 # heyy how u doin


### PR DESCRIPTION
Fixes #74

The language allows us to do this (for convenience). This PR adds fixes support for that.

The technique used is a bit similar to the one I used for Syntax
Highlighting.

## Before

A "comment" block was considered a "raw" tag block. We'd parse it like this:

- match `/{%-?\s*comment\s*-?%}/`
  - that's the `.blockStart` of the tag
- match all characters until one that is _followed_ by `/{%-?\s*endcomment\s*-?%}/`
  - that's the `body` of the tag
- match `/{%-?\s*endcomment\s*-?%}/`
  - that's the `.blockEnd` of the tag

This approach _didn't_ work for nested tags, since we'd match over the `{% comment %}` of the nested comment and stop at the `{% endcomment %}` of the nested comment. Leaving us with a dangling comment body and `{% endcomment %}`.

Something like this:

```liquid
{% comment %}
This is inside the comment
  {% comment %}
    nested
  {% endcomment}
This is outside the comment since we stoped parsing on the previous line
{% endcomment %}
```

## After

Slightly different algorithm. We parse like this:

- match `/{%-?\s*comment\s*-?%}/`
  - that's the `.blockStart` of the tag
- match as many of the following two things (the concatenated list is the body of the tag):
  1. Another comment block (recursive rule)
  2. all characters until one that is _followed_ by one of those two:
    - `/{%-?\s*comment\s*-?%}`
    - `/{%-?\s*endcomment\s*-?%}/`
- match `/{%-?\s*endcomment\s*-?%}`
  - that's the `.blockEnd` of the tag

The "trick" here is that we stop parsing on nested `{% comment %}` and try to recurse on the rule.

So this will work:

```liquid
{% comment %}
This is inside the comment
{% comment %}
  this is nested inside a recursed rule
{% endcomment %}
This is inside the top comment
{% endcomment %}
```
