### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Requirements:
 - Yarn
 
 ```
-git clone git@github.com/shopify/prettier-plugin-liquid
+git clone git@github.com:Shopify/prettier-plugin-liquid.git
 yarn
 yarn test
 ```


### PR DESCRIPTION
### What does this do?
Simple README update to fix the link for cloning the repo

### Issue fixed by this change
<img width="598" alt="image" src="https://user-images.githubusercontent.com/35415298/200448600-64e32ef1-55f5-4f0e-8cc1-8caf6c4f3c24.png">

