### PR TITLE
Add support for the `stylesheet` tag

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -30,6 +30,7 @@ Helpers {
 Liquid <: Helpers {
   Node := (liquidNode | TextNode)*
   openControl := "{{" | "{%"
+  endOfIdentifier = space | "-%}" | "%}"
 
   liquidNode =
     | liquidBlockComment
@@ -166,13 +167,14 @@ Liquid <: Helpers {
     | liquidRawTagImpl<"raw">
     | liquidRawTagImpl<"javascript">
     | liquidRawTagImpl<"schema">
+    | liquidRawTagImpl<"stylesheet">
     | liquidRawTagImpl<"style">
   liquidRawTagImpl<name> =
-    "{%" "-"? space* name space* tagMarkup "-"? "%}"
+    "{%" "-"? space* (name &endOfIdentifier) space* tagMarkup "-"? "%}"
     anyExceptStar<liquidRawTagClose<name>>
-    "{%" "-"? space* "end" name space* "-"? "%}"
+    "{%" "-"? space* "end" (name &endOfIdentifier) space* "-"? "%}"
   liquidRawTagClose<name> =
-    "{%" "-"? space* "end" name space* "-"? "%}"
+    "{%" "-"? space* "end" (name &endOfIdentifier) space* "-"? "%}"
 
   liquidBlockComment =
     commentBlockStart

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -108,6 +108,7 @@ export interface LiquidRawTag extends ASTNode<NodeTypes.LiquidRawTag> {
    * e.g. raw, style, javascript
    */
   name: string;
+  markup: string;
 
   /**
    * String body of the tag. So we don't try to parse it.
@@ -627,6 +628,7 @@ export function cstToAst(
       case ConcreteNodeTypes.LiquidRawTag: {
         builder.push({
           type: NodeTypes.LiquidRawTag,
+          markup: markup(node.name, node.markup),
           name: node.name,
           body: toRawMarkup(node, source),
           whitespaceStart: node.whitespaceStart ?? '',
@@ -1181,6 +1183,7 @@ function toRawMarkupKindFromLiquidNode(
   switch (node.name) {
     case 'javascript':
       return RawMarkupKinds.javascript;
+    case 'stylesheet':
     case 'style':
       if (liquidToken.test(node.body)) {
         return RawMarkupKinds.text;

--- a/src/parser/cst.ts
+++ b/src/parser/cst.ts
@@ -137,6 +137,7 @@ export interface ConcreteLiquidRawTag
   extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidRawTag> {
   name: string;
   body: string;
+  markup: string;
   delimiterWhitespaceStart: null | '-';
   delimiterWhitespaceEnd: null | '-';
   blockStartLocStart: number;
@@ -510,17 +511,18 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     liquidRawTagImpl: {
       type: ConcreteNodeTypes.LiquidRawTag,
       name: 3,
-      body: 8,
+      body: 9,
+      markup: 6,
       whitespaceStart: 1,
-      whitespaceEnd: 6,
-      delimiterWhitespaceStart: 10,
-      delimiterWhitespaceEnd: 15,
+      whitespaceEnd: 7,
+      delimiterWhitespaceStart: 11,
+      delimiterWhitespaceEnd: 17,
       locStart,
       locEnd,
       blockStartLocStart: (tokens: Node[]) => tokens[0].source.startIdx,
-      blockStartLocEnd: (tokens: Node[]) => tokens[7].source.endIdx,
-      blockEndLocStart: (tokens: Node[]) => tokens[9].source.startIdx,
-      blockEndLocEnd: (tokens: Node[]) => tokens[16].source.endIdx,
+      blockStartLocEnd: (tokens: Node[]) => tokens[8].source.endIdx,
+      blockEndLocStart: (tokens: Node[]) => tokens[10].source.startIdx,
+      blockEndLocEnd: (tokens: Node[]) => tokens[18].source.endIdx,
     },
     liquidBlockComment: {
       type: ConcreteNodeTypes.LiquidRawTag,

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -469,6 +469,7 @@ export function printLiquidRawTag(
         ' ',
         node.name,
         ' ',
+        node.markup ? `${node.markup} ` : '',
         node.whitespaceEnd,
         '%}',
       ]);

--- a/test/embed-liquid-stylesheet-tag/fixed.liquid
+++ b/test/embed-liquid-stylesheet-tag/fixed.liquid
@@ -1,0 +1,21 @@
+It should pretty print CSS inside stylesheet tags
+printWidth: 20
+{% stylesheet %}
+  .class,
+  #id,
+  html,
+  body {
+    background-color: green;
+    width: 100%;
+  }
+  .container {
+    display: flex;
+  }
+{% endstylesheet %}
+
+It should fallback to reindenting when it doesn't parse
+printWidth: 20
+{% stylesheet %}
+  .class,#id,html,body{background-color:{{setting.color}};width:100%}
+  .container{display:flex;}
+{% endstylesheet %}

--- a/test/embed-liquid-stylesheet-tag/index.liquid
+++ b/test/embed-liquid-stylesheet-tag/index.liquid
@@ -1,0 +1,13 @@
+It should pretty print CSS inside stylesheet tags
+printWidth: 20
+{% stylesheet %}
+.class,#id,html,body{background-color:green;width:100%}
+.container{display:flex;}
+{% endstylesheet %}
+
+It should fallback to reindenting when it doesn't parse
+printWidth: 20
+{% stylesheet %}
+.class,#id,html,body{background-color:{{setting.color}};width:100%}
+.container{display:flex;}
+{% endstylesheet %}

--- a/test/embed-liquid-stylesheet-tag/index.spec.ts
+++ b/test/embed-liquid-stylesheet-tag/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-string-fallback/fixed.liquid
+++ b/test/liquid-tag-string-fallback/fixed.liquid
@@ -6,5 +6,4 @@ It pastes LiquidTagOpen.markup that it can't parse as is with spaces trimmed on 
 {% tablerow element bin collection %}{% endtablerow %}
 
 It pastes LiquidRawTag.markup that it can't parse as is with spaces trimmed on both ends
-{% stylesheet wat|| %}
-{% endstylesheet %}
+{% stylesheet wat|| %} {% endstylesheet %}


### PR DESCRIPTION
Last week I learned [`{% style %}`](https://shopify.dev/api/liquid/tags#style) != [`{% stylesheet %}`](https://shopify.dev/themes/architecture/sections/section-assets#stylesheet) in Liquid.

The output is different, but their API is the same: they both take CSS as body.

In this PR:

- Duplicate the support we have for the `style` tag with `stylesheet`
- Prevent parsing collision of `{%schema-%}` since `-` is an identifier character.
- Prevent parsing collision of `{% style %}` and `{% stylesheet %}` since `s` is an identifier character.

Fixes #116
