### PR TITLE
Internal refactor of parser pipeline

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -5,7 +5,7 @@ import {
   liquidHtmlLanguageName,
 } from '~/parser/parser';
 
-export * from '~/parser/ast';
+export * from '~/parser/stage-2-ast';
 
 export { liquidHtmlLanguageName, liquidHtmlAstFormat };
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,6 +1,6 @@
 import { Parser, ParserOptions } from 'prettier';
 import { locEnd, locStart } from '~/utils';
-import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/ast';
+import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/stage-2-ast';
 
 export function parse(
   text: string,

--- a/src/parser/stage-1-cst.spec.ts
+++ b/src/parser/stage-1-cst.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { LiquidHtmlCST, toLiquidHtmlCST } from '~/parser/cst';
+import { LiquidHtmlCST, toLiquidHtmlCST } from '~/parser/stage-1-cst';
 import { BLOCKS, VOID_ELEMENTS } from '~/parser/grammar';
 import { NamedTags } from '~/types';
 import { deepGet } from '~/utils';

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -91,6 +91,7 @@ export interface Parsers {
 
 export interface ConcreteBasicNode<T> {
   type: T;
+  source: string;
   locStart: number;
   locEnd: number;
 }
@@ -474,6 +475,7 @@ interface TemplateMapping {
   type: ConcreteNodeTypes;
   locStart: (node: Node[]) => number;
   locEnd: (node: Node[]) => number;
+  source: string;
   [k: string]: FunctionMapping | string | number | boolean | object | null;
 }
 
@@ -484,7 +486,7 @@ const markup = (i: number) => (tokens: Node[]) => tokens[i].sourceString.trim();
 const markupTrimEnd = (i: number) => (tokens: Node[]) =>
   tokens[i].sourceString.trimEnd();
 
-export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
+export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
   // When we switch parser, our locStart and locEnd functions must account
   // for the offset of the {% liquid %} markup
   let liquidStatementOffset = 0;
@@ -502,9 +504,10 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
     },
     locStart,
     locEnd,
+    source,
   };
 
-  const res = liquidHtmlGrammar.match(text, 'Node');
+  const res = liquidHtmlGrammar.match(source, 'Node');
   if (res.failed()) {
     throw new LiquidHTMLCSTParsingError(res);
   }
@@ -551,6 +554,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       delimiterWhitespaceEnd: 17,
       locStart,
       locEnd,
+      source,
       blockStartLocStart: (tokens: Node[]) => tokens[0].source.startIdx,
       blockStartLocEnd: (tokens: Node[]) => tokens[8].source.endIdx,
       blockEndLocStart: (tokens: Node[]) => tokens[10].source.startIdx,
@@ -568,6 +572,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
         tokens[2].children[6].sourceString,
       locStart,
       locEnd,
+      source,
       blockStartLocStart: (tokens: Node[]) => tokens[0].source.startIdx,
       blockStartLocEnd: (tokens: Node[]) => tokens[0].source.endIdx,
       blockEndLocStart: (tokens: Node[]) => tokens[2].source.startIdx,
@@ -581,6 +586,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: 6,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTagOpen: 0,
@@ -600,6 +606,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: 6,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTagOpenCapture: 0,
@@ -614,6 +621,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       args: 8,
       locStart,
       locEnd,
+      source,
     },
     liquidTagOpenTablerow: 0,
     liquidTagOpenPaginate: 0,
@@ -624,6 +632,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       args: 6,
       locStart,
       locEnd,
+      source,
     },
     liquidTagOpenCase: 0,
     liquidTagOpenCaseMarkup: 0,
@@ -639,6 +648,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       expression: 2,
       locStart,
       locEnd,
+      source,
     },
     comparison: {
       type: ConcreteNodeTypes.Comparison,
@@ -647,6 +657,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       right: 4,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTagClose: {
@@ -656,6 +667,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: 7,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTag: 0,
@@ -682,6 +694,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       },
       whitespaceStart: 1,
       whitespaceEnd: 6,
+      source,
       locStart,
       locEnd,
     },
@@ -718,6 +731,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 4,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTagCycleMarkup: {
@@ -726,6 +740,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       args: 3,
       locStart,
       locEnd,
+      source,
     },
 
     liquidTagRenderMarkup: {
@@ -736,6 +751,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       args: 4,
       locStart,
       locEnd,
+      source,
     },
     snippetExpression: 0,
     renderVariableExpression: {
@@ -744,6 +760,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       name: 3,
       locStart,
       locEnd,
+      source,
     },
     renderAliasExpression: 3,
 
@@ -754,6 +771,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: 4,
       locStart,
       locEnd,
+      source,
     },
 
     liquidDropCases: 0,
@@ -764,13 +782,14 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       expression: 0,
       filters: 1,
       rawSource: (tokens: Node[]) =>
-        text
+        source
           .slice(locStart(tokens), tokens[tokens.length - 2].source.endIdx)
           .trimEnd(),
       locStart,
       // The last node of this rule is a positive lookahead, we don't
       // want its endIdx, we want the endIdx of the previous one.
       locEnd: (tokens: Node[]) => tokens[tokens.length - 2].source.endIdx,
+      source,
     },
 
     liquidFilter: {
@@ -778,6 +797,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       name: 3,
       locStart,
       locEnd,
+      source,
       args(nodes: Node[]) {
         // Traditinally, this would get transformed into null or array. But
         // it's better if we have an empty array instead of null here.
@@ -797,6 +817,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 4,
       locStart,
       locEnd,
+      source,
     },
 
     liquidString: 0,
@@ -806,6 +827,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 1,
       locStart,
       locEnd,
+      source,
     },
     liquidSingleQuotedString: {
       type: ConcreteNodeTypes.String,
@@ -813,6 +835,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 1,
       locStart,
       locEnd,
+      source,
     },
 
     liquidNumber: {
@@ -820,6 +843,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 0,
       locStart,
       locEnd,
+      source,
     },
 
     liquidLiteral: {
@@ -832,6 +856,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       keyword: 0,
       locStart,
       locEnd,
+      source,
     },
 
     liquidRange: {
@@ -840,6 +865,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       end: 6,
       locStart,
       locEnd,
+      source,
     },
 
     liquidVariableLookup: {
@@ -848,6 +874,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       lookups: 1,
       locStart,
       locEnd,
+      source,
     },
     variableSegmentAsLookupMarkup: 0,
     variableSegmentAsLookup: {
@@ -856,6 +883,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       lookups: () => [],
       locStart,
       locEnd,
+      source,
     },
 
     lookup: 0,
@@ -865,6 +893,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 3,
       locStart: (nodes: Node[]) => nodes[2].source.startIdx,
       locEnd: (nodes: Node[]) => nodes[nodes.length - 1].source.endIdx,
+      source,
     },
 
     // trim on both sides
@@ -888,6 +917,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: null,
       locStart,
       locEnd: locEndSecondToLast,
+      source,
     },
 
     liquidTagClose: {
@@ -897,6 +927,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: null,
       locStart,
       locEnd: locEndSecondToLast,
+      source,
     },
 
     liquidTagRule: {
@@ -914,6 +945,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: null,
       locStart,
       locEnd: locEndSecondToLast,
+      source,
     },
 
     liquidRawTagImpl: {
@@ -926,6 +958,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       delimiterWhitespaceEnd: null,
       locStart,
       locEnd: locEndSecondToLast,
+      source,
       blockStartLocStart: (tokens: Node[]) =>
         liquidStatementOffset + tokens[0].source.startIdx,
       blockStartLocEnd: (tokens: Node[]) =>
@@ -953,6 +986,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       delimiterWhitespaceEnd: '',
       locStart,
       locEnd,
+      source,
       blockStartLocStart: (tokens: Node[]) =>
         liquidStatementOffset + tokens[0].source.startIdx,
       blockStartLocEnd: (tokens: Node[]) =>
@@ -971,6 +1005,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       whitespaceEnd: null,
       locStart,
       locEnd: locEndSecondToLast,
+      source,
     },
   };
 
@@ -990,6 +1025,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       body: 2,
       locStart,
       locEnd,
+      source,
     },
 
     HtmlDoctype: {
@@ -997,6 +1033,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       legacyDoctypeString: 4,
       locStart,
       locEnd,
+      source,
     },
 
     HtmlComment: {
@@ -1004,6 +1041,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       body: markup(1),
       locStart,
       locEnd,
+      source,
     },
 
     HtmlRawTagImpl: {
@@ -1013,6 +1051,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       body: 4,
       locStart,
       locEnd,
+      source,
       blockStartLocStart: (tokens: any) => tokens[0].source.startIdx,
       blockStartLocEnd: (tokens: any) => tokens[3].source.endIdx,
       blockEndLocStart: (tokens: any) => tokens[5].source.startIdx,
@@ -1025,6 +1064,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       attrList: 3,
       locStart,
       locEnd,
+      source,
     },
 
     HtmlSelfClosingElement: {
@@ -1033,6 +1073,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       attrList: 2,
       locStart,
       locEnd,
+      source,
     },
 
     HtmlTagOpen: {
@@ -1041,6 +1082,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       attrList: 2,
       locStart,
       locEnd,
+      source,
     },
 
     HtmlTagClose: {
@@ -1048,6 +1090,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       name: 1,
       locStart,
       locEnd,
+      source,
     },
 
     tagNameOrLiquidDrop: 0,
@@ -1058,6 +1101,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 2,
       locStart,
       locEnd,
+      source,
     },
 
     AttrSingleQuoted: {
@@ -1066,6 +1110,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 3,
       locStart,
       locEnd,
+      source,
     },
 
     AttrDoubleQuoted: {
@@ -1074,6 +1119,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       value: 3,
       locStart,
       locEnd,
+      source,
     },
 
     attrEmpty: {
@@ -1081,6 +1127,7 @@ export function toLiquidHtmlCST(text: string): LiquidHtmlCST {
       name: 0,
       locStart,
       locEnd,
+      source,
     },
 
     attrDoubleQuotedValue: 0,

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -1,3 +1,35 @@
+/**
+ * This is the first stage of the parser.
+ *
+ * Input:
+ *   Source code: string
+ *
+ * Output:
+ *   Concrete Syntax Tree (CST): LiquidHtmlCST
+ *
+ * We use OhmJS's toAST method to turn the OhmJS nodes into an "almost-AST." We
+ * call that a Concrete Syntax Tree because it considers Open and Close nodes as
+ * separate nodes.
+ *
+ * It is mostly "flat."
+ *
+ * e.g.
+ * {% if cond %}hi <em>there!</em>{% endif %}
+ *
+ * becomes
+ * - LiquidTagOpen/if
+ *   condition: LiquidVariableExpression/cond
+ * - TextNode/"hi "
+ * - HtmlTagOpen/em
+ * - TextNode/"there!"
+ * - HtmlTagClose/em
+ * - LiquidTagClose/if
+ *
+ * In the Concrete Syntax Tree, all nodes are siblings instead of having a
+ * parent/children relationship.
+ *
+ */
+
 import { Parser } from 'prettier';
 import { Node } from 'ohm-js';
 import { toAST } from 'ohm-js/extras';

--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/ast';
+import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/stage-2-ast';
 import { deepGet } from '~/utils';
 
 describe('Unit: toLiquidHtmlAST', () => {

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -1,3 +1,38 @@
+/**
+ * This is the second stage of the parser.
+ *
+ * Input:
+ *  - A Concrete Syntax Tree (CST)
+ *
+ * Output:
+ *  - An Abstract Syntax Tree (AST)
+ *
+ * This stage traverses the flat tree we get from the previous stage and
+ * establishes the parent/child relationship between the nodes.
+ *
+ * Recall the Liquid example we had in the first stage:
+ *   {% if cond %}hi <em>there!</em>{% endif %}
+ *
+ * Whereas the previous stage gives us this CST:
+ *   - LiquidTagOpen/if
+ *     condition: LiquidVariableExpression/cond
+ *   - TextNode/"hi "
+ *   - HtmlTagOpen/em
+ *   - TextNode/"there!"
+ *   - HtmlTagClose/em
+ *   - LiquidTagClose/if
+ *
+ * We now traverse all the nodes and turn that into a proper AST:
+ *   - LiquidTag/if
+ *     condition: LiquidVariableExpression
+ *     children:
+ *       - TextNode/"hi "
+ *       - HtmlElement/em
+ *         children:
+ *           - TextNode/"there!"
+ *
+ */
+
 import {
   ConcreteAttributeNode,
   ConcreteHtmlTagClose,
@@ -34,7 +69,7 @@ import {
   ConcreteLiquidTagCycleMarkup,
   ConcreteHtmlRawTag,
   ConcreteLiquidRawTag,
-} from '~/parser/cst';
+} from '~/parser/stage-1-cst';
 import {
   Comparators,
   isLiquidHtmlNode,

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -498,16 +498,16 @@ function isLiquidBranchDisguisedAsTag(
   );
 }
 
-export function toLiquidHtmlAST(text: string): DocumentNode {
-  const cst = toLiquidHtmlCST(text);
+export function toLiquidHtmlAST(source: string): DocumentNode {
+  const cst = toLiquidHtmlCST(source);
   const root: DocumentNode = {
     type: NodeTypes.Document,
-    source: text,
-    children: cstToAst(cst, text),
+    source: source,
+    children: cstToAst(cst),
     name: '#document',
     position: {
       start: 0,
-      end: text.length,
+      end: source.length,
     },
   };
   return root;
@@ -543,7 +543,7 @@ class ASTBuilder {
     this.cursor.push('children');
 
     if (isBranchedTag(node)) {
-      this.open(toUnnamedLiquidBranch(node, this.source));
+      this.open(toUnnamedLiquidBranch(node));
     }
   }
 
@@ -554,7 +554,7 @@ class ASTBuilder {
     ) {
       this.cursor.pop();
       this.cursor.pop();
-      this.open(toNamedLiquidBranchBaseCase(node, this.source));
+      this.open(toNamedLiquidBranchBaseCase(node));
     } else if (node.type === NodeTypes.LiquidBranch) {
       this.cursor.pop();
       this.cursor.pop();
@@ -624,9 +624,9 @@ function getName(
 
 export function cstToAst(
   cst: LiquidHtmlCST | ConcreteAttributeNode[],
-  source: string,
 ): LiquidHtmlNode[] {
-  const builder = new ASTBuilder(source);
+  if (cst.length === 0) return [];
+  const builder = new ASTBuilder(cst[0].source);
 
   for (const node of cst) {
     switch (node.type) {
@@ -635,18 +635,18 @@ export function cstToAst(
           type: NodeTypes.TextNode,
           value: node.value,
           position: position(node),
-          source,
+          source: node.source,
         });
         break;
       }
 
       case ConcreteNodeTypes.LiquidDrop: {
-        builder.push(toLiquidDrop(node, source));
+        builder.push(toLiquidDrop(node));
         break;
       }
 
       case ConcreteNodeTypes.LiquidTagOpen: {
-        builder.open(toLiquidTag(node, source, { isBlockTag: true }));
+        builder.open(toLiquidTag(node, { isBlockTag: true }));
         break;
       }
 
@@ -656,7 +656,7 @@ export function cstToAst(
       }
 
       case ConcreteNodeTypes.LiquidTag: {
-        builder.push(toLiquidTag(node, source));
+        builder.push(toLiquidTag(node));
         break;
       }
 
@@ -665,7 +665,7 @@ export function cstToAst(
           type: NodeTypes.LiquidRawTag,
           markup: markup(node.name, node.markup),
           name: node.name,
-          body: toRawMarkup(node, source),
+          body: toRawMarkup(node),
           whitespaceStart: node.whitespaceStart ?? '',
           whitespaceEnd: node.whitespaceEnd ?? '',
           delimiterWhitespaceStart: node.delimiterWhitespaceStart ?? '',
@@ -679,13 +679,13 @@ export function cstToAst(
             start: node.blockEndLocStart,
             end: node.blockEndLocEnd,
           },
-          source,
+          source: node.source,
         });
         break;
       }
 
       case ConcreteNodeTypes.HtmlTagOpen: {
-        builder.open(toHtmlElement(node, source));
+        builder.open(toHtmlElement(node));
         break;
       }
 
@@ -695,12 +695,12 @@ export function cstToAst(
       }
 
       case ConcreteNodeTypes.HtmlVoidElement: {
-        builder.push(toHtmlVoidElement(node, source));
+        builder.push(toHtmlVoidElement(node));
         break;
       }
 
       case ConcreteNodeTypes.HtmlSelfClosingElement: {
-        builder.push(toHtmlSelfClosingElement(node, source));
+        builder.push(toHtmlSelfClosingElement(node));
         break;
       }
 
@@ -709,7 +709,7 @@ export function cstToAst(
           type: NodeTypes.HtmlDoctype,
           legacyDoctypeString: node.legacyDoctypeString,
           position: position(node),
-          source,
+          source: node.source,
         });
         break;
       }
@@ -719,7 +719,7 @@ export function cstToAst(
           type: NodeTypes.HtmlComment,
           body: node.body,
           position: position(node),
-          source,
+          source: node.source,
         });
         break;
       }
@@ -728,10 +728,10 @@ export function cstToAst(
         builder.push({
           type: NodeTypes.HtmlRawNode,
           name: node.name,
-          body: toRawMarkup(node, source),
-          attributes: toAttributes(node.attrList || [], source),
+          body: toRawMarkup(node),
+          attributes: toAttributes(node.attrList || []),
           position: position(node),
-          source,
+          source: node.source,
           blockStartPosition: {
             start: node.blockStartLocStart,
             end: node.blockStartLocEnd,
@@ -749,7 +749,7 @@ export function cstToAst(
           type: NodeTypes.AttrEmpty,
           name: node.name,
           position: position(node),
-          source,
+          source: node.source,
         });
         break;
       }
@@ -765,13 +765,13 @@ export function cstToAst(
               | NodeTypes.AttrUnquoted,
             name: node.name,
             position: position(node),
-            source,
+            source: node.source,
 
             // placeholders
             attributePosition: { start: -1, end: -1 },
             value: [],
           };
-        const value = toAttributeValue(node.value, source);
+        const value = toAttributeValue(node.value);
         abstractNode.value = value;
         abstractNode.attributePosition = toAttributePosition(node, value);
         builder.push(abstractNode);
@@ -783,7 +783,7 @@ export function cstToAst(
           type: NodeTypes.YAMLFrontmatter,
           body: node.body,
           position: position(node),
-          source,
+          source: node.source,
         });
         break;
       }
@@ -829,26 +829,21 @@ function toAttributePosition(
 
 function toAttributeValue(
   value: (ConcreteLiquidNode | ConcreteTextNode)[],
-  source: string,
 ): (LiquidNode | TextNode)[] {
-  return cstToAst(value, source) as (LiquidNode | TextNode)[];
+  return cstToAst(value) as (LiquidNode | TextNode)[];
 }
 
-function toAttributes(
-  attrList: ConcreteAttributeNode[],
-  source: string,
-): AttributeNode[] {
-  return cstToAst(attrList, source) as AttributeNode[];
+function toAttributes(attrList: ConcreteAttributeNode[]): AttributeNode[] {
+  return cstToAst(attrList) as AttributeNode[];
 }
 
-function toName(name: string | ConcreteLiquidDrop, source: string) {
+function toName(name: string | ConcreteLiquidDrop) {
   if (typeof name === 'string') return name;
-  return toLiquidDrop(name, source);
+  return toLiquidDrop(name);
 }
 
 function liquidTagBaseAttributes(
   node: ConcreteLiquidTag | ConcreteLiquidTagOpen,
-  source: string,
 ): Omit<LiquidTag, 'name' | 'markup'> {
   return {
     type: NodeTypes.LiquidTag,
@@ -856,13 +851,12 @@ function liquidTagBaseAttributes(
     whitespaceStart: node.whitespaceStart ?? '',
     whitespaceEnd: node.whitespaceEnd ?? '',
     blockStartPosition: position(node),
-    source,
+    source: node.source,
   };
 }
 
 function liquidBranchBaseAttributes(
   node: ConcreteLiquidTag,
-  source: string,
 ): Omit<LiquidBranch, 'name' | 'markup'> {
   return {
     type: NodeTypes.LiquidBranch,
@@ -871,75 +865,73 @@ function liquidBranchBaseAttributes(
     whitespaceStart: node.whitespaceStart ?? '',
     whitespaceEnd: node.whitespaceEnd ?? '',
     blockStartPosition: position(node),
-    source,
+    source: node.source,
   };
 }
 
 function toLiquidTag(
   node: ConcreteLiquidTag | ConcreteLiquidTagOpen,
-  source: string,
   { isBlockTag } = { isBlockTag: false },
 ): LiquidTag | LiquidBranch {
   if (typeof node.markup !== 'string') {
-    return toNamedLiquidTag(node as ConcreteLiquidTagNamed, source);
+    return toNamedLiquidTag(node as ConcreteLiquidTagNamed);
   } else if (isBlockTag) {
     return {
       name: node.name,
       markup: markup(node.name, node.markup),
       children: isBlockTag ? [] : undefined,
-      ...liquidTagBaseAttributes(node, source),
+      ...liquidTagBaseAttributes(node),
     };
   }
   return {
     name: node.name,
     markup: markup(node.name, node.markup),
-    ...liquidTagBaseAttributes(node, source),
+    ...liquidTagBaseAttributes(node),
   };
 }
 
 function toNamedLiquidTag(
   node: ConcreteLiquidTagNamed | ConcreteLiquidTagOpenNamed,
-  source: string,
 ): LiquidTagNamed | LiquidBranchNamed {
   switch (node.name) {
     case NamedTags.echo: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: NamedTags.echo,
-        markup: toLiquidVariable(node.markup, source),
+        markup: toLiquidVariable(node.markup),
       };
     }
 
     case NamedTags.assign: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: NamedTags.assign,
-        markup: toAssignMarkup(node.markup, source),
+        markup: toAssignMarkup(node.markup),
       };
     }
 
     case NamedTags.cycle: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toCycleMarkup(node.markup, source),
+        markup: toCycleMarkup(node.markup),
       };
     }
 
     case NamedTags.increment:
     case NamedTags.decrement: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toExpression(node.markup, source) as LiquidVariableLookup,
+        markup: toExpression(node.markup) as LiquidVariableLookup,
       };
     }
 
     case NamedTags.capture: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toExpression(node.markup, source) as LiquidVariableLookup,
+        markup: toExpression(node.markup) as LiquidVariableLookup,
         children: [],
       };
     }
@@ -947,26 +939,26 @@ function toNamedLiquidTag(
     case NamedTags.include:
     case NamedTags.render: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toRenderMarkup(node.markup, source),
+        markup: toRenderMarkup(node.markup),
       };
     }
 
     case NamedTags.layout:
     case NamedTags.section: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toExpression(node.markup, source) as LiquidString,
+        markup: toExpression(node.markup) as LiquidString,
       };
     }
 
     case NamedTags.form: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: node.markup.map((arg) => toLiquidArgument(arg, source)),
+        markup: node.markup.map(toLiquidArgument),
         children: [],
       };
     }
@@ -974,18 +966,18 @@ function toNamedLiquidTag(
     case NamedTags.tablerow:
     case NamedTags.for: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toForMarkup(node.markup, source),
+        markup: toForMarkup(node.markup),
         children: [],
       };
     }
 
     case NamedTags.paginate: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toPaginateMarkup(node.markup, source),
+        markup: toPaginateMarkup(node.markup),
         children: [],
       };
     }
@@ -993,43 +985,43 @@ function toNamedLiquidTag(
     case NamedTags.if:
     case NamedTags.unless: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toConditionalExpression(node.markup, source),
+        markup: toConditionalExpression(node.markup),
         children: [],
       };
     }
 
     case NamedTags.elsif: {
       return {
-        ...liquidBranchBaseAttributes(node, source),
+        ...liquidBranchBaseAttributes(node),
         name: node.name,
-        markup: toConditionalExpression(node.markup, source),
+        markup: toConditionalExpression(node.markup),
       };
     }
 
     case NamedTags.case: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: toExpression(node.markup, source),
+        markup: toExpression(node.markup),
         children: [],
       };
     }
 
     case NamedTags.when: {
       return {
-        ...liquidBranchBaseAttributes(node, source),
+        ...liquidBranchBaseAttributes(node),
         name: node.name,
-        markup: node.markup.map((arg) => toExpression(arg, source)),
+        markup: node.markup.map(toExpression),
       };
     }
 
     case NamedTags.liquid: {
       return {
-        ...liquidTagBaseAttributes(node, source),
+        ...liquidTagBaseAttributes(node),
         name: node.name,
-        markup: cstToAst(node.markup, source) as LiquidStatement[],
+        markup: cstToAst(node.markup) as LiquidStatement[],
       };
     }
 
@@ -1041,7 +1033,6 @@ function toNamedLiquidTag(
 
 function toNamedLiquidBranchBaseCase(
   node: LiquidTagBaseCase,
-  source: string,
 ): LiquidBranchBaseCase {
   return {
     name: node.name,
@@ -1052,13 +1043,12 @@ function toNamedLiquidBranchBaseCase(
     blockStartPosition: { ...node.position },
     whitespaceStart: node.whitespaceStart,
     whitespaceEnd: node.whitespaceEnd,
-    source,
+    source: node.source,
   };
 }
 
 function toUnnamedLiquidBranch(
   parentNode: LiquidHtmlNode,
-  source: string,
 ): LiquidBranchUnnamed {
   return {
     type: NodeTypes.LiquidBranch,
@@ -1075,68 +1065,55 @@ function toUnnamedLiquidBranch(
     children: [],
     whitespaceStart: '',
     whitespaceEnd: '',
-    source,
+    source: parentNode.source,
   };
 }
 
-function toAssignMarkup(
-  node: ConcreteLiquidTagAssignMarkup,
-  source: string,
-): AssignMarkup {
+function toAssignMarkup(node: ConcreteLiquidTagAssignMarkup): AssignMarkup {
   return {
     type: NodeTypes.AssignMarkup,
     name: node.name,
-    value: toLiquidVariable(node.value, source),
+    value: toLiquidVariable(node.value),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toCycleMarkup(
-  node: ConcreteLiquidTagCycleMarkup,
-  source: string,
-): CycleMarkup {
+function toCycleMarkup(node: ConcreteLiquidTagCycleMarkup): CycleMarkup {
   return {
     type: NodeTypes.CycleMarkup,
-    groupName: node.groupName ? toExpression(node.groupName, source) : null,
-    args: node.args.map((arg) => toExpression(arg, source)),
+    groupName: node.groupName ? toExpression(node.groupName) : null,
+    args: node.args.map(toExpression),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toForMarkup(
-  node: ConcreteLiquidTagForMarkup,
-  source: string,
-): ForMarkup {
+function toForMarkup(node: ConcreteLiquidTagForMarkup): ForMarkup {
   return {
     type: NodeTypes.ForMarkup,
     variableName: node.variableName,
-    collection: toExpression(node.collection, source),
-    args: node.args.map((arg) => toNamedArgument(arg, source)),
+    collection: toExpression(node.collection),
+    args: node.args.map(toNamedArgument),
     reversed: !!node.reversed,
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toPaginateMarkup(
-  node: ConcretePaginateMarkup,
-  source: string,
-): PaginateMarkup {
+function toPaginateMarkup(node: ConcretePaginateMarkup): PaginateMarkup {
   return {
     type: NodeTypes.PaginateMarkup,
-    collection: toExpression(node.collection, source),
-    pageSize: toExpression(node.pageSize, source),
+    collection: toExpression(node.collection),
+    pageSize: toExpression(node.pageSize),
     position: position(node),
-    args: node.args ? node.args.map((arg) => toNamedArgument(arg, source)) : [],
-    source,
+    args: node.args ? node.args.map(toNamedArgument) : [],
+    source: node.source,
   };
 }
 
 function toRawMarkup(
   node: ConcreteHtmlRawTag | ConcreteLiquidRawTag,
-  source: string,
 ): RawMarkup {
   return {
     type: NodeTypes.RawMarkup,
@@ -1146,7 +1123,7 @@ function toRawMarkup(
       start: node.blockStartLocEnd,
       end: node.blockEndLocStart,
     },
-    source,
+    source: node.source,
   };
 }
 
@@ -1231,43 +1208,36 @@ function toRawMarkupKindFromLiquidNode(
   }
 }
 
-function toRenderMarkup(
-  node: ConcreteLiquidTagRenderMarkup,
-  source: string,
-): RenderMarkup {
+function toRenderMarkup(node: ConcreteLiquidTagRenderMarkup): RenderMarkup {
   return {
     type: NodeTypes.RenderMarkup,
-    snippet: toExpression(node.snippet, source) as
-      | LiquidString
-      | LiquidVariableLookup,
+    snippet: toExpression(node.snippet) as LiquidString | LiquidVariableLookup,
     alias: node.alias,
-    variable: toRenderVariableExpression(node.variable, source),
-    args: node.args.map((arg) => toNamedArgument(arg, source)),
+    variable: toRenderVariableExpression(node.variable),
+    args: node.args.map(toNamedArgument),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
 function toRenderVariableExpression(
   node: ConcreteRenderVariableExpression | null,
-  source: string,
 ): RenderVariableExpression | null {
   if (!node) return null;
   return {
     type: NodeTypes.RenderVariableExpression,
     kind: node.kind,
-    name: toExpression(node.name, source),
+    name: toExpression(node.name),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
 function toConditionalExpression(
   nodes: ConcreteLiquidCondition[],
-  source: string,
 ): LiquidConditionalExpression {
   if (nodes.length === 1) {
-    return toComparisonOrExpression(nodes[0], source);
+    return toComparisonOrExpression(nodes[0]);
   }
 
   const [first, second] = nodes;
@@ -1275,75 +1245,65 @@ function toConditionalExpression(
   return {
     type: NodeTypes.LogicalExpression,
     relation: second.relation as 'and' | 'or',
-    left: toComparisonOrExpression(first, source),
-    right: toConditionalExpression(rest, source),
+    left: toComparisonOrExpression(first),
+    right: toConditionalExpression(rest),
     position: {
       start: first.locStart,
       end: nodes[nodes.length - 1].locEnd,
     },
-    source,
+    source: first.source,
   };
 }
 
 function toComparisonOrExpression(
   node: ConcreteLiquidCondition,
-  source: string,
 ): LiquidComparison | LiquidExpression {
   const expression = node.expression;
   switch (expression.type) {
     case ConcreteNodeTypes.Comparison:
-      return toComparison(expression, source);
+      return toComparison(expression);
     default:
-      return toExpression(expression, source);
+      return toExpression(expression);
   }
 }
 
-function toComparison(
-  node: ConcreteLiquidComparison,
-  source: string,
-): LiquidComparison {
+function toComparison(node: ConcreteLiquidComparison): LiquidComparison {
   return {
     type: NodeTypes.Comparison,
     comparator: node.comparator,
-    left: toExpression(node.left, source),
-    right: toExpression(node.right, source),
+    left: toExpression(node.left),
+    right: toExpression(node.right),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toLiquidDrop(node: ConcreteLiquidDrop, source: string): LiquidDrop {
+function toLiquidDrop(node: ConcreteLiquidDrop): LiquidDrop {
   return {
     type: NodeTypes.LiquidDrop,
     markup:
       typeof node.markup === 'string'
         ? node.markup
-        : toLiquidVariable(node.markup, source),
+        : toLiquidVariable(node.markup),
     whitespaceStart: node.whitespaceStart ?? '',
     whitespaceEnd: node.whitespaceEnd ?? '',
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toLiquidVariable(
-  node: ConcreteLiquidVariable,
-  source: string,
-): LiquidVariable {
+function toLiquidVariable(node: ConcreteLiquidVariable): LiquidVariable {
   return {
     type: NodeTypes.LiquidVariable,
-    expression: toExpression(node.expression, source),
-    filters: node.filters.map((filter) => toFilter(filter, source)),
+    expression: toExpression(node.expression),
+    filters: node.filters.map(toFilter),
     position: position(node),
     rawSource: node.rawSource,
-    source,
+    source: node.source,
   };
 }
 
-function toExpression(
-  node: ConcreteLiquidExpression,
-  source: string,
-): LiquidExpression {
+function toExpression(node: ConcreteLiquidExpression): LiquidExpression {
   switch (node.type) {
     case ConcreteNodeTypes.String: {
       return {
@@ -1351,7 +1311,7 @@ function toExpression(
         position: position(node),
         single: node.single,
         value: node.value,
-        source,
+        source: node.source,
       };
     }
     case ConcreteNodeTypes.Number: {
@@ -1359,7 +1319,7 @@ function toExpression(
         type: NodeTypes.Number,
         position: position(node),
         value: node.value,
-        source,
+        source: node.source,
       };
     }
     case ConcreteNodeTypes.LiquidLiteral: {
@@ -1368,25 +1328,25 @@ function toExpression(
         position: position(node),
         value: node.value,
         keyword: node.keyword,
-        source,
+        source: node.source,
       };
     }
     case ConcreteNodeTypes.Range: {
       return {
         type: NodeTypes.Range,
-        start: toExpression(node.start, source),
-        end: toExpression(node.end, source),
+        start: toExpression(node.start),
+        end: toExpression(node.end),
         position: position(node),
-        source,
+        source: node.source,
       };
     }
     case ConcreteNodeTypes.VariableLookup: {
       return {
         type: NodeTypes.VariableLookup,
         name: node.name,
-        lookups: node.lookups.map((lookup) => toExpression(lookup, source)),
+        lookups: node.lookups.map(toExpression),
         position: position(node),
-        source,
+        source: node.source,
       };
     }
     default: {
@@ -1395,81 +1355,73 @@ function toExpression(
   }
 }
 
-function toFilter(node: ConcreteLiquidFilter, source: string): LiquidFilter {
+function toFilter(node: ConcreteLiquidFilter): LiquidFilter {
   return {
     type: NodeTypes.LiquidFilter,
     name: node.name,
-    args: node.args.map((arg) => toLiquidArgument(arg, source)),
+    args: node.args.map(toLiquidArgument),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toLiquidArgument(
-  node: ConcreteLiquidArgument,
-  source: string,
-): LiquidArgument {
+function toLiquidArgument(node: ConcreteLiquidArgument): LiquidArgument {
   switch (node.type) {
     case ConcreteNodeTypes.NamedArgument: {
-      return toNamedArgument(node, source);
+      return toNamedArgument(node);
     }
     default: {
-      return toExpression(node, source);
+      return toExpression(node);
     }
   }
 }
 
 function toNamedArgument(
   node: ConcreteLiquidNamedArgument,
-  source: string,
 ): LiquidNamedArgument {
   return {
     type: NodeTypes.NamedArgument,
     name: node.name,
-    value: toExpression(node.value, source),
+    value: toExpression(node.value),
     position: position(node),
-    source,
+    source: node.source,
   };
 }
 
-function toHtmlElement(node: ConcreteHtmlTagOpen, source: string): HtmlElement {
+function toHtmlElement(node: ConcreteHtmlTagOpen): HtmlElement {
   return {
     type: NodeTypes.HtmlElement,
-    name: toName(node.name, source),
-    attributes: toAttributes(node.attrList || [], source),
+    name: toName(node.name),
+    attributes: toAttributes(node.attrList || []),
     position: position(node),
     blockStartPosition: position(node),
     blockEndPosition: { start: -1, end: -1 },
     children: [],
-    source,
+    source: node.source,
   };
 }
 
-function toHtmlVoidElement(
-  node: ConcreteHtmlVoidElement,
-  source: string,
-): HtmlVoidElement {
+function toHtmlVoidElement(node: ConcreteHtmlVoidElement): HtmlVoidElement {
   return {
     type: NodeTypes.HtmlVoidElement,
     name: node.name,
-    attributes: toAttributes(node.attrList || [], source),
+    attributes: toAttributes(node.attrList || []),
     position: position(node),
     blockStartPosition: position(node),
-    source,
+    source: node.source,
   };
 }
 
 function toHtmlSelfClosingElement(
   node: ConcreteHtmlSelfClosingElement,
-  source: string,
 ): HtmlSelfClosingElement {
   return {
     type: NodeTypes.HtmlSelfClosingElement,
-    name: toName(node.name, source),
-    attributes: toAttributes(node.attrList || [], source),
+    name: toName(node.name),
+    attributes: toAttributes(node.attrList || []),
     position: position(node),
     blockStartPosition: position(node),
-    source,
+    source: node.source,
   };
 }
 

--- a/src/printer/print-preprocess.ts
+++ b/src/printer/print-preprocess.ts
@@ -1,4 +1,4 @@
-import * as AST from '~/parser/ast';
+import * as AST from '~/parser/stage-2-ast';
 import { LiquidParserOptions, DocumentNode } from '~/types';
 import { AUGMENTATION_PIPELINE } from '~/printer/preprocess';
 

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -14,7 +14,7 @@ import {
   LiquidRawTag,
   LiquidStatement,
 } from '~/types';
-import { isBranchedTag } from '~/parser/ast';
+import { isBranchedTag } from '~/parser/stage-2-ast';
 import { assertNever } from '~/utils';
 
 import {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Doc, AstPath, ParserOptions } from 'prettier';
-import * as AST from '~/parser/ast';
+import * as AST from '~/parser/stage-2-ast';
 
 export interface Position {
   start: number;


### PR DESCRIPTION
- Renames (objective make the flow more obvious)
  - `cst.ts` -> `stage-1-cst.ts`,
  - `ast.ts` -> `stage-2-ast.ts`
- Add explainer comments at head of both files
- Make the CST responsible for setting `.source` on the nodes
  - Cleans up wiring of `source` argument in all the methods in `stage-2-ast.ts`
