### PR TITLE
Fix the rendering of html tags with one attribute that is multiline

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -11,6 +11,13 @@
       "options": {
         "printWidth": 100
       }
+    },
+    {
+      "files": "*.liquid",
+      "options": {
+        "singleQuote": false,
+        "printWidth": 80
+      }
     }
   ]
 }

--- a/src/printer/print/tag.ts
+++ b/src/printer/print/tag.ts
@@ -26,6 +26,7 @@ import {
   isMultilineLiquidTag,
   hasMeaningfulLackOfLeadingWhitespace,
   hasMeaningfulLackOfTrailingWhitespace,
+  last,
 } from '~/printer/utils';
 
 const {
@@ -310,6 +311,13 @@ function printAttributes(
       : print(attributePath, { trailingSpaceGroupId: attrGroupId });
   }, 'attributes');
 
+  const forceBreakAttrContent =
+    node.attributes &&
+    node.attributes.length > 0 &&
+    node.source
+      .slice(node.blockStartPosition.start, last(node.attributes).position.end)
+      .includes('\n');
+
   const forceNotToBreakAttrContent =
     (options.singleLineLinkTags &&
       typeof node.name === 'string' &&
@@ -317,14 +325,10 @@ function printAttributes(
     ((isSelfClosing(node) ||
       isVoidElement(node) ||
       (isHtmlElement(node) && node.children.length > 0)) &&
+      !forceBreakAttrContent &&
       node.attributes &&
       node.attributes.length === 1 &&
       !isLiquidNode(node.attributes[0]));
-
-  const forceBreakAttrContent =
-    node.source
-      .slice(node.blockStartPosition.start, node.blockStartPosition.end)
-      .indexOf('\n') !== -1;
 
   const attributeLine = forceNotToBreakAttrContent
     ? ' '

--- a/test/issue-120/fixed.liquid
+++ b/test/issue-120/fixed.liquid
@@ -1,0 +1,13 @@
+it should format as expected
+<c-header>
+  <header
+    class="
+      relative z-[10]
+      pt-2 pb-8 md:pt-6 md:pb-12
+      container
+      flex flex-wrap gap-x-2 sm:gap-x-6
+    "
+  >
+    <div class="shrink-0 w-full max-xl:mb-[-1px]"></div>
+  </header>
+</c-header>

--- a/test/issue-120/index.liquid
+++ b/test/issue-120/index.liquid
@@ -1,0 +1,13 @@
+it should format as expected
+<c-header>
+  <header
+    class="
+      relative z-[10]
+      pt-2 pb-8 md:pt-6 md:pb-12
+      container
+      flex flex-wrap gap-x-2 sm:gap-x-6
+    "
+  >
+    <div class="shrink-0 w-full max-xl:mb-[-1px]"></div>
+  </header>
+</c-header>

--- a/test/issue-120/index.spec.ts
+++ b/test/issue-120/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
We have a special rule to prevent awkward multiline breaks, this doesn't
play well when the input already was multilne.

Fixes #120
