### PR TITLE
Add unit tests for weird `{% style %}` tag reformating

### DIFF
--- a/test/embed-liquid-style-tag/fixed.liquid
+++ b/test/embed-liquid-style-tag/fixed.liquid
@@ -26,3 +26,12 @@ useTabs: true
 	.class,#id,html,body{background-color:{{setting.color}};width:100%}
 	.container{display:flex;}
 {% endstyle %}
+
+It should fallback to reindenting when it contains liquid in calc. (somehow this parses!)
+{%- style -%}
+  @media screen and (max-width: 749px) {
+    .collection-hero--with-image .collection-hero__inner {
+      padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);
+    }
+  }
+{%- endstyle -%}

--- a/test/embed-liquid-style-tag/index.liquid
+++ b/test/embed-liquid-style-tag/index.liquid
@@ -18,3 +18,12 @@ useTabs: true
     .class,#id,html,body{background-color:{{setting.color}};width:100%}
     .container{display:flex;}
 {% endstyle %}
+
+It should fallback to reindenting when it contains liquid in calc. (somehow this parses!)
+{%- style -%}
+@media screen and (max-width: 749px) {
+  .collection-hero--with-image .collection-hero__inner {
+    padding-bottom: calc({{ settings.media_shadow_vertical_offset | at_least: 0 }}px + 2rem);
+  }
+}
+{%- endstyle -%}


### PR DESCRIPTION
No change of functionality, verifies an [issue](https://github.com/Shopify/dawn/pull/2126#discussion_r1023237668) raised in Dawn. 

Fixes #119
