### PR TITLE
Add support for `prettier-ignore-attributes` and fix secondary templating parsing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ Prettier for Liquid supports the following options.
 | `singleLineLinkTags`        | `false`   | If set to `true`, will print `<link>` tags on a single line to remove clutter                                                                                            |
 | `indentSchema`              | `false`   | If set to `true`, will indent the contents of the `{% schema %}` tag                                                                                                     |
 
+## Ignoring code
+
+We support the following comments (either via HTML or Liquid comments):
+
+- `prettier-ignore`
+- `prettier-ignore-attribute`
+- `prettier-ignore-attributes` (alias)
+
+They target the next node in the tree. Unparseable code can't be ignored and will throw an error.
+
+```liquid
+{% # prettier-ignore %}
+<div         class="x"       >hello world</div            >
+
+{% # prettier-ignore-attributes %}
+<div
+  [[#if Condition]]
+    class="a b c"
+  [[/if ]]
+></div>
+```
+
 ## Known issues
 
 Take a look at our [known issues](./KNOWN_ISSUES.md) and [open issues](https://github.com/Shopify/prettier-plugin-liquid/issues).

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -404,7 +404,7 @@ LiquidHTML <: Liquid {
   AttrDoubleQuoted = attrName "=" "\"" #(attrDoubleQuotedValue "\"")
 
   // https://html.spec.whatwg.org/#attributes-2
-  attrName = anyExceptPlus<(space | quotes | "=" | ">" | "/" | "{{" | "{%" | controls | noncharacters)>
+  attrName = anyExceptPlus<(space | quotes | "=" | ">" | "/>" | "{{" | "{%" | controls | noncharacters)>
   attrUnquotedValue = (attrUnquotedTextNode)*
   attrSingleQuotedValue = (liquidNode | attrSingleQuotedTextNode)*
   attrDoubleQuotedValue = (liquidNode | attrDoubleQuotedTextNode)*

--- a/src/parser/grammar.spec.ts
+++ b/src/parser/grammar.spec.ts
@@ -28,6 +28,16 @@ describe('Unit: liquidHtmlGrammar', () => {
         </body>
       </html>
     `).to.be.true;
+    expectMatchSucceeded(`
+      <input
+        class="[[ cssClasses.checkbox ]] form-checkbox sm:text-[8px]"
+        type="checkbox"
+
+        [[# isRefined ]]
+          checked
+        [[/ isRefined ]]
+      />
+    `).to.be.true;
     expectMatchSucceeded('<img {% if aboveFold %} loading="lazy"{% endif %} />').to.be.true;
     expectMatchSucceeded('<svg><use></svg>').to.be.true;
   });

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -298,6 +298,9 @@ function printNode(
           endTag,
         ];
       }
+      if (node.body.includes('prettier-ignore')) {
+        return node.source.slice(node.position.start, node.position.end);
+      }
       return [
         '<!--',
         group([

--- a/test/issue-123/fixed.liquid
+++ b/test/issue-123/fixed.liquid
@@ -1,0 +1,11 @@
+it should format as expected
+<!-- prettier-ignore-attribute -->
+<div
+  class="[[ cssClasses.checkbox ]] form-checkbox sm:text-[8px]"
+  type="checkbox"
+  [[# isRefined ]]
+    checked
+  [[/ isRefined ]]
+>
+  hello
+</div>

--- a/test/issue-123/index.liquid
+++ b/test/issue-123/index.liquid
@@ -1,0 +1,11 @@
+it should format as expected
+<!-- prettier-ignore-attribute -->
+<div
+  class="[[ cssClasses.checkbox ]] form-checkbox sm:text-[8px]"
+  type="checkbox"
+  [[# isRefined ]]
+    checked
+  [[/ isRefined ]]
+>
+hello
+</div>

--- a/test/issue-123/index.spec.ts
+++ b/test/issue-123/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/prettier-ignore-attribute/fixed.liquid
+++ b/test/prettier-ignore-attribute/fixed.liquid
@@ -1,0 +1,48 @@
+It should be typo-proof and indent attributes
+printWidth: 1
+<!-- prettier-ignore-attribute -->
+<p
+  (mouseup)=" wat " (mousedown)=" wat "
+>
+  hello
+</p>
+<!-- prettier-ignore-attributes -->
+<p
+  (mouseup)=" wat " (mousedown)=" wat "
+>
+  hello
+</p>
+
+It should respect html whitespace sensitivity
+printWidth: 1
+<!-- prettier-ignore-attributes -->
+<a
+  (mouseup)=" wat " (mousedown)=" wat "
+  >hello</a
+>
+
+It should print all attributes as is (pw40)
+printWidth: 40
+<!-- prettier-ignore-attribute -->
+<a (mouseup)=" wat " (mousedown)=" wat "
+  >hello</a
+>
+
+It should respect indentation and multiple attributes per line input
+printWidth: 1
+<!-- prettier-ignore-attributes -->
+<a
+  [[#if Something]]
+    href="abc"
+  [[/if ]]
+  >hello</a
+>
+
+It should work with Liquid inline comments
+printWidth: 1
+{% # prettier-ignore-attribute %}
+<p
+  (mouseup)=" wat " (mousedown)=" wat "
+>
+  hello
+</p>

--- a/test/prettier-ignore-attribute/index.liquid
+++ b/test/prettier-ignore-attribute/index.liquid
@@ -1,0 +1,30 @@
+It should be typo-proof and indent attributes
+printWidth: 1
+<!-- prettier-ignore-attribute -->
+<p (mouseup)=" wat " (mousedown)=" wat ">hello</p>
+<!-- prettier-ignore-attributes -->
+<p (mouseup)=" wat " (mousedown)=" wat ">hello</p>
+
+It should respect html whitespace sensitivity
+printWidth: 1
+<!-- prettier-ignore-attributes -->
+<a (mouseup)=" wat " (mousedown)=" wat ">hello</a>
+
+It should print all attributes as is (pw40)
+printWidth: 40
+<!-- prettier-ignore-attribute -->
+<a (mouseup)=" wat " (mousedown)=" wat ">hello</a>
+
+It should respect indentation and multiple attributes per line input
+printWidth: 1
+<!-- prettier-ignore-attributes -->
+<a
+  [[#if Something]]
+    href="abc"
+  [[/if ]]
+>hello</a>
+
+It should work with Liquid inline comments
+printWidth: 1
+{% # prettier-ignore-attribute %}
+<p (mouseup)=" wat " (mousedown)=" wat ">hello</p>

--- a/test/prettier-ignore-attribute/index.spec.ts
+++ b/test/prettier-ignore-attribute/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Document how to ignore nodes with `prettier-ignore` and `prettier-ignore-attributes`
- Fixup support for `prettier-ignore-attributes`
- Be less picky about `anyExcept` rule in attributes. `[[/if` should parse just fine.

Fixes #123
