### PR TITLE
Allow for liquid output in attribute names

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -404,7 +404,8 @@ LiquidHTML <: Liquid {
   AttrDoubleQuoted = attrName "=" "\"" #(attrDoubleQuotedValue "\"")
 
   // https://html.spec.whatwg.org/#attributes-2
-  attrName = anyExceptPlus<(space | quotes | "=" | ">" | "/>" | "{{" | "{%" | controls | noncharacters)>
+  attrName = (liquidDrop | attrNameTextNode)+
+  attrNameTextNode = anyExceptPlus<(space | quotes | "=" | ">" | "/>" | "{{" | "{%" | controls | noncharacters)>
   attrUnquotedValue = (attrUnquotedTextNode)*
   attrSingleQuotedValue = (liquidNode | attrSingleQuotedTextNode)*
   attrDoubleQuotedValue = (liquidNode | attrDoubleQuotedTextNode)*

--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -406,7 +406,7 @@ LiquidHTML <: Liquid {
   // https://html.spec.whatwg.org/#attributes-2
   attrName = (liquidDrop | attrNameTextNode)+
   attrNameTextNode = anyExceptPlus<(space | quotes | "=" | ">" | "/>" | "{{" | "{%" | controls | noncharacters)>
-  attrUnquotedValue = (attrUnquotedTextNode)*
+  attrUnquotedValue = (liquidDrop | attrUnquotedTextNode)*
   attrSingleQuotedValue = (liquidNode | attrSingleQuotedTextNode)*
   attrDoubleQuotedValue = (liquidNode | attrDoubleQuotedTextNode)*
 

--- a/src/parser/grammar.spec.ts
+++ b/src/parser/grammar.spec.ts
@@ -38,6 +38,7 @@ describe('Unit: liquidHtmlGrammar', () => {
         [[/ isRefined ]]
       />
     `).to.be.true;
+    expectMatchSucceeded(`<div data-popup-{{ section.id }}="size-{{ section.id }}">`).to.be.true;
     expectMatchSucceeded('<img {% if aboveFold %} loading="lazy"{% endif %} />').to.be.true;
     expectMatchSucceeded('<svg><use></svg>').to.be.true;
   });

--- a/src/parser/stage-1-cst.spec.ts
+++ b/src/parser/stage-1-cst.spec.ts
@@ -88,7 +88,7 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
         cst = toLiquidHtmlCST(`<${voidElementName} disabled>`);
         expectPath(cst, '0.type').to.equal('HtmlVoidElement');
         expectPath(cst, '0.name').to.equal(voidElementName);
-        expectPath(cst, '0.attrList.0.name').to.equal('disabled');
+        expectPath(cst, '0.attrList.0.name').to.eql(['disabled']);
       });
     });
 
@@ -96,7 +96,7 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
       ['<div empty>', '<div empty >', '<div\nempty\n>'].forEach((text) => {
         cst = toLiquidHtmlCST(text);
         expectPath(cst, '0.attrList.0.type').to.equal('AttrEmpty');
-        expectPath(cst, '0.attrList.0.name').to.equal('empty');
+        expectPath(cst, '0.attrList.0.name').to.eql(['empty']);
         expectPath(cst, '0.name.attrList.0.value').to.be.undefined;
       });
     });
@@ -114,7 +114,7 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
         ].forEach((text) => {
           cst = toLiquidHtmlCST(text);
           expectPath(cst, '0.attrList.0.type').to.equal(testConfig.type);
-          expectPath(cst, '0.attrList.0.name').to.equal(testConfig.name);
+          expectPath(cst, '0.attrList.0.name').to.eql([testConfig.name]);
           expectPath(cst, '0.attrList.0.value.0.type').to.eql('TextNode');
           expectPath(cst, '0.attrList.0.value.0.value').to.eql(testConfig.name);
         });

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -132,7 +132,7 @@ export interface ConcreteHtmlTagClose
   extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlTagClose> {}
 
 export interface ConcreteAttributeNodeBase<T> extends ConcreteBasicNode<T> {
-  name: string;
+  name: (ConcreteLiquidDrop | string)[];
   value: (ConcreteLiquidNode | ConcreteTextNode)[];
 }
 
@@ -151,7 +151,7 @@ export interface ConcreteAttrUnquoted
   extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrUnquoted> {}
 export interface ConcreteAttrEmpty
   extends ConcreteBasicNode<ConcreteNodeTypes.AttrEmpty> {
-  name: string;
+  name: (ConcreteLiquidDrop | string)[];
 }
 
 export type ConcreteLiquidNode =
@@ -1130,6 +1130,8 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
       source,
     },
 
+    attrName: 0,
+    attrNameTextNode: 0,
     attrDoubleQuotedValue: 0,
     attrSingleQuotedValue: 0,
     attrUnquotedValue: 0,

--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -531,14 +531,14 @@ describe('Unit: toLiquidHtmlAST', () => {
     expectPath(ast, 'children.0').to.exist;
     expectPath(ast, 'children.0.type').to.eql('HtmlVoidElement');
     expectPath(ast, 'children.0.name').to.eql('img');
-    expectPath(ast, 'children.0.attributes.0.name').to.eql('src');
+    expectPath(ast, 'children.0.attributes.0.name').to.eql(['src']);
     expectPath(ast, 'children.0.attributes.0.value.0.type').to.eql('TextNode');
     expectPath(ast, 'children.0.attributes.0.value.0.value').to.eql('https://1234');
-    expectPath(ast, 'children.0.attributes.1.name').to.eql('loading');
+    expectPath(ast, 'children.0.attributes.1.name').to.eql(['loading']);
     expectPath(ast, 'children.0.attributes.1.value.0.type').to.eql('TextNode');
     expectPath(ast, 'children.0.attributes.1.value.0.value').to.eql('lazy');
-    expectPath(ast, 'children.0.attributes.2.name').to.eql('disabled');
-    expectPath(ast, 'children.0.attributes.3.name').to.eql('checked');
+    expectPath(ast, 'children.0.attributes.2.name').to.eql(['disabled']);
+    expectPath(ast, 'children.0.attributes.3.name').to.eql(['checked']);
     expectPath(ast, 'children.0.attributes.3.value.0').to.be.undefined;
 
     expectPosition(ast, 'children.0');
@@ -582,13 +582,13 @@ describe('Unit: toLiquidHtmlAST', () => {
       expectPath(ast, 'children.0.name.type').to.eql('LiquidDrop');
       expectPath(ast, 'children.0.name.markup.type').to.eql('LiquidVariable');
       expectPath(ast, 'children.0.name.markup.rawSource').to.eql('node_type');
-      expectPath(ast, 'children.0.attributes.0.name').to.eql('src');
+      expectPath(ast, 'children.0.attributes.0.name').to.eql(['src']);
       expectPath(ast, 'children.0.attributes.0.value.0.type').to.eql('TextNode');
       expectPath(ast, 'children.0.attributes.0.value.0.value').to.eql('https://1234');
-      expectPath(ast, 'children.0.attributes.1.name').to.eql('loading');
+      expectPath(ast, 'children.0.attributes.1.name').to.eql(['loading']);
       expectPath(ast, 'children.0.attributes.1.value.0.type').to.eql('TextNode');
       expectPath(ast, 'children.0.attributes.1.value.0.value').to.eql('lazy');
-      expectPath(ast, 'children.0.attributes.2.name').to.eql('disabled');
+      expectPath(ast, 'children.0.attributes.2.name').to.eql(['disabled']);
     });
   });
 

--- a/src/printer/preprocess/augment-with-whitespace-helpers.ts
+++ b/src/printer/preprocess/augment-with-whitespace-helpers.ts
@@ -109,10 +109,20 @@ function isIndentationSensitiveNode(node: AugmentedAstNode) {
  * A node is leading whitespace sensitive when whitespace to the outer left
  * of it has meaning. Removing or adding whitespace there would alter the
  * rendered output.
+ * <div attr-{{ hi }}
  */
 function isLeadingWhitespaceSensitiveNode(node: AugmentedAstNode): boolean {
   if (!node) {
     return false;
+  }
+
+  // <a data-{{ this }}="hi">
+  if (
+    node.parentNode &&
+    isAttributeNode(node.parentNode) &&
+    node.type === NodeTypes.LiquidDrop
+  ) {
+    return true;
   }
 
   // {{- this }}
@@ -213,6 +223,15 @@ function isTrailingWhitespaceSensitiveNode(node: AugmentedAstNode): boolean {
   // '{{ drop -}} text'
   if (isTrimmingOuterRight(node)) {
     return false;
+  }
+
+  // <a data-{{ this }}="hi">
+  if (
+    node.parentNode &&
+    isAttributeNode(node.parentNode) &&
+    node.type === NodeTypes.LiquidDrop
+  ) {
+    return true;
   }
 
   // 'text {{- drop }}'

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -49,7 +49,7 @@ import { embed } from '~/printer/embed';
 import { RawMarkupKinds } from '~/parser';
 import { getConditionalComment } from '~/parser/conditional-comment';
 
-const { builders } = doc;
+const { builders, utils } = doc;
 const { fill, group, hardline, indent, join, line, softline } = builders;
 
 const oppositeQuotes = {
@@ -71,7 +71,9 @@ function printAttributeName(
       if (typeof value === 'string') {
         return value;
       } else {
-        return print(part as AstPath<LiquidDrop>);
+        // We want to force the LiquidDrop to be on one line to avoid weird
+        // shenanigans
+        return utils.removeLines(print(part as AstPath<LiquidDrop>));
       }
     }, 'name'),
   );

--- a/test/html-attributes/fixed.liquid
+++ b/test/html-attributes/fixed.liquid
@@ -147,3 +147,7 @@ singleQuote: true
 If singleQuote is false, and the attribute value has liquid tags that contain double quotes, don't care.
 singleQuote: false
 <script src="{{ "styles.css" | asset_url }}"></script>
+
+It should pretty print attribute names with Liquid in them
+singleQuote: true
+<div data-popup-{{ section.id }}='size-{{ section.id }}'></div>

--- a/test/html-attributes/fixed.liquid
+++ b/test/html-attributes/fixed.liquid
@@ -157,3 +157,6 @@ printWidth: 1
 <div
   data-popup-{{ section.id | upcase }}="size-{{ section.id }}"
 ></div>
+
+It should pretty unquoted liquid drop attributes
+<div id="{{ section.id }}--omg"></div>

--- a/test/html-attributes/fixed.liquid
+++ b/test/html-attributes/fixed.liquid
@@ -151,3 +151,9 @@ singleQuote: false
 It should pretty print attribute names with Liquid in them
 singleQuote: true
 <div data-popup-{{ section.id }}='size-{{ section.id }}'></div>
+
+It should pretty print attribute names with Liquid in them without new lines
+printWidth: 1
+<div
+  data-popup-{{ section.id | upcase }}="size-{{ section.id }}"
+></div>

--- a/test/html-attributes/index.liquid
+++ b/test/html-attributes/index.liquid
@@ -97,3 +97,7 @@ singleQuote: false
 It should pretty print attribute names with Liquid in them
 singleQuote: true
 <div data-popup-{{section.id}}="size-{{ section.id }}"></div>
+
+It should pretty print attribute names with Liquid in them without new lines
+printWidth: 1
+<div data-popup-{{section.id|upcase}}="size-{{ section.id }}"></div>

--- a/test/html-attributes/index.liquid
+++ b/test/html-attributes/index.liquid
@@ -93,3 +93,7 @@ singleQuote: true
 If singleQuote is false, and the attribute value has liquid tags that contain double quotes, don't care.
 singleQuote: false
 <script src="{{ "styles.css" | asset_url }}"></script>
+
+It should pretty print attribute names with Liquid in them
+singleQuote: true
+<div data-popup-{{section.id}}="size-{{ section.id }}"></div>

--- a/test/html-attributes/index.liquid
+++ b/test/html-attributes/index.liquid
@@ -101,3 +101,6 @@ singleQuote: true
 It should pretty print attribute names with Liquid in them without new lines
 printWidth: 1
 <div data-popup-{{section.id|upcase}}="size-{{ section.id }}"></div>
+
+It should pretty unquoted liquid drop attributes
+<div id={{ section.id }}--omg></div>


### PR DESCRIPTION
Examples:

```liquid
{% # AttrDoubleQuoted with Liquid in attribute name %}
<a data-popup--{{ section.id }}="placeholder">

{% # AttrEmpty with Liquid in attribute name %}
<a data-popup--{{ section.id }}>
```

In this PR:
- Change the Ohm parsing rule for `attrName` from `attrNameTextNode` to `(liquidDrop | attributeNameTextNode)*`
- Change the CST `AttributeNode.name` type from `string` to `(string | ConcreteLiquidDrop)[]`
- Change the AST `AttributeNode.name` type from `string` to `(string | LiquidDrop)[]`
- Change the printing rules for `AttributeNode` to ≈ `join('', attr.name.map(print))`;

Fixes #101
