### PR TITLE
Fixup parsing of `{% else-%}`

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -30,7 +30,9 @@ Helpers {
 Liquid <: Helpers {
   Node := (liquidNode | TextNode)*
   openControl := "{{" | "{%"
-  endOfIdentifier = space | "-%}" | "%}"
+  endOfTagName = &("-%}" | "-}}" | "%}" | "}}")
+  endOfVarName = ~identifierCharacter
+  endOfIdentifier = endOfTagName | endOfVarName
 
   liquidNode =
     | liquidBlockComment
@@ -70,9 +72,9 @@ Liquid <: Helpers {
 
   // These two are the same but transformed differently
   liquidTagRule<name, markup> =
-    "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
+    "{%" "-"? space* (name endOfIdentifier) space* markup "-"? "%}"
   liquidTagOpenRule<name, markup> =
-    "{%" "-"? space* (name ~identifierCharacter) space* markup "-"? "%}"
+    "{%" "-"? space* (name endOfIdentifier) space* markup "-"? "%}"
 
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
 
@@ -170,18 +172,18 @@ Liquid <: Helpers {
     | liquidRawTagImpl<"stylesheet">
     | liquidRawTagImpl<"style">
   liquidRawTagImpl<name> =
-    "{%" "-"? space* (name &endOfIdentifier) space* tagMarkup "-"? "%}"
+    "{%" "-"? space* (name endOfIdentifier) space* tagMarkup "-"? "%}"
     anyExceptStar<liquidRawTagClose<name>>
-    "{%" "-"? space* "end" (name &endOfIdentifier) space* "-"? "%}"
+    "{%" "-"? space* "end" (name endOfIdentifier) space* "-"? "%}"
   liquidRawTagClose<name> =
-    "{%" "-"? space* "end" (name &endOfIdentifier) space* "-"? "%}"
+    "{%" "-"? space* "end" (name endOfIdentifier) space* "-"? "%}"
 
   liquidBlockComment =
     commentBlockStart
       (liquidBlockComment | anyExceptPlus<(commentBlockStart | commentBlockEnd)>)*
     commentBlockEnd
-  commentBlockStart = "{%" "-"? space* ("comment"    ~identifierCharacter) space* tagMarkup "-"? "%}"
-  commentBlockEnd   = "{%" "-"? space* ("endcomment" ~identifierCharacter) space* tagMarkup "-"? "%}"
+  commentBlockStart = "{%" "-"? space* ("comment"    endOfIdentifier) space* tagMarkup "-"? "%}"
+  commentBlockEnd   = "{%" "-"? space* ("endcomment" endOfIdentifier) space* tagMarkup "-"? "%}"
 
   // In order for the grammar to "fallback" to the base case, this
   // rule must pass if and only if we support what we parse. This
@@ -215,7 +217,7 @@ Liquid <: Helpers {
     | "empty"
     | "nil"
     | "null"
-    ) ~identifierCharacter
+    ) endOfIdentifier
 
   liquidRange =
     "(" space* liquidExpression space* ".." space* liquidExpression space* ")"
@@ -259,7 +261,7 @@ Liquid <: Helpers {
     | "if"
     | "unless"
     | "tablerow"
-    ) ~identifierCharacter
+    ) endOfIdentifier
 }
 
 LiquidStatement <: Liquid {

--- a/src/parser/grammar.spec.ts
+++ b/src/parser/grammar.spec.ts
@@ -12,6 +12,11 @@ describe('Unit: liquidHtmlGrammar', () => {
     expectMatchSucceeded(`{{product.feature}}`).to.be.true;
     expectMatchSucceeded(`{%- if A -%}`).to.be.true;
     expectMatchSucceeded(`{%-if A-%}`).to.be.true;
+    expectMatchSucceeded(`{%- else-%}`).to.be.true;
+    expectMatchSucceeded(`{%- liquid-%}`).to.be.true;
+    expectMatchSucceeded(`{%- schema-%}`).to.be.true;
+    expectMatchSucceeded(`{%- form-%}`).to.be.true;
+    expectMatchSucceeded(`{{ true-}}`).to.be.true;
     expectMatchSucceeded(`
       <html>
         <head>

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -565,11 +565,11 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
       name: 'comment',
       body: (tokens: Node[]) => tokens[1].sourceString,
       whitespaceStart: (tokens: Node[]) => tokens[0].children[1].sourceString,
-      whitespaceEnd: (tokens: Node[]) => tokens[0].children[6].sourceString,
+      whitespaceEnd: (tokens: Node[]) => tokens[0].children[7].sourceString,
       delimiterWhitespaceStart: (tokens: Node[]) =>
         tokens[2].children[1].sourceString,
       delimiterWhitespaceEnd: (tokens: Node[]) =>
-        tokens[2].children[6].sourceString,
+        tokens[2].children[7].sourceString,
       locStart,
       locEnd,
       source,
@@ -595,7 +595,7 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
       type: ConcreteNodeTypes.LiquidTagOpen,
       name: 3,
       markup(nodes: Node[]) {
-        const markupNode = nodes[5];
+        const markupNode = nodes[6];
         const nameNode = nodes[3];
         if (NamedTags.hasOwnProperty(nameNode.sourceString)) {
           return markupNode.toAST((this as any).args.mapping);
@@ -603,7 +603,7 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
         return markupNode.sourceString.trim();
       },
       whitespaceStart: 1,
-      whitespaceEnd: 6,
+      whitespaceEnd: 7,
       locStart,
       locEnd,
       source,
@@ -685,7 +685,7 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
       type: ConcreteNodeTypes.LiquidTag,
       name: 3,
       markup(nodes: Node[]) {
-        const markupNode = nodes[5];
+        const markupNode = nodes[6];
         const nameNode = nodes[3];
         if (NamedTags.hasOwnProperty(nameNode.sourceString)) {
           return markupNode.toAST((this as any).args.mapping);
@@ -693,7 +693,7 @@ export function toLiquidHtmlCST(source: string): LiquidHtmlCST {
         return markupNode.sourceString.trim();
       },
       whitespaceStart: 1,
-      whitespaceEnd: 6,
+      whitespaceEnd: 7,
       source,
       locStart,
       locEnd,


### PR DESCRIPTION
This is a weird parsing ambiguity problem.

Before, our rule was the following:

```
identifierCharacter = alnum | "_" | "-"
liquidTagBaseCase = "{%" space* (tagName ~identifierCharacter) space* tagMarkup "-"? "%}"
```

Our problem was that `-` is both an identifier character and the character we use for stripping whitespace from the end of tags and variable output (`-%}` and `-}}`).

So `{% else-%}` threw an error because `tagName` _was_ followed by `-`, which is an identifier character.

The solution is to change that rule to the following:
- Followed by an "end of tag" `-}}`, `-%}`, OR
- Not followed by an identifierCharacter

Fixes #126
