### PR TITLE
Parse smart quotes as dumb quotes to prevent formatted copy pasting errors

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -22,6 +22,8 @@ Helpers {
   nonemptyOrderedListOfBoth<a, b, sep> =
     nonemptyListOf<a, sep> (sep nonemptyListOf<b, sep>)
 
+  singleQuote = "'" | "‘" | "’"
+  doubleQuote = "\"" | "“" | "”"
   controls = "\u{007F}".."\u{009F}"
   noncharacters = "\u{FDD0}".."\u{FDEF}"
   newline = "\r"? "\n"
@@ -411,8 +413,8 @@ LiquidHTML <: Liquid {
   attrEmpty = attrName
 
   AttrUnquoted = attrName "=" attrUnquotedValue
-  AttrSingleQuoted = attrName "=" "'" #(attrSingleQuotedValue "'")
-  AttrDoubleQuoted = attrName "=" "\"" #(attrDoubleQuotedValue "\"")
+  AttrSingleQuoted = attrName "=" singleQuote #(attrSingleQuotedValue singleQuote)
+  AttrDoubleQuoted = attrName "=" doubleQuote #(attrDoubleQuotedValue doubleQuote)
 
   attrName = (liquidDrop | attrNameTextNode)+
 
@@ -423,10 +425,10 @@ LiquidHTML <: Liquid {
   attrDoubleQuotedValue = (liquidNode | attrDoubleQuotedTextNode)*
 
   attrUnquotedTextNode = anyExceptPlus<(space | quotes | "=" | "<" | ">" | "`" | "{{" | "{%")>
-  attrSingleQuotedTextNode = anyExceptPlus<("'" | "{{" | "{%")>
-  attrDoubleQuotedTextNode = anyExceptPlus<("\""| "{{" | "{%")>
+  attrSingleQuotedTextNode = anyExceptPlus<(singleQuote | "{{" | "{%")>
+  attrDoubleQuotedTextNode = anyExceptPlus<(doubleQuote | "{{" | "{%")>
 
-  quotes =  "'" | "\""
+  quotes = singleQuote | doubleQuote
 
   // https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
   voidElementName =

--- a/src/parser/stage-1-cst.spec.ts
+++ b/src/parser/stage-1-cst.spec.ts
@@ -132,7 +132,11 @@ describe('Unit: toLiquidHtmlCST(text)', () => {
 
     [
       { type: 'AttrSingleQuoted', name: 'single', quote: "'" },
+      { type: 'AttrSingleQuoted', name: 'single', quote: '‘' },
+      { type: 'AttrSingleQuoted', name: 'single', quote: '’' },
       { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
+      { type: 'AttrDoubleQuoted', name: 'double', quote: '“' },
+      { type: 'AttrDoubleQuoted', name: 'double', quote: '”' },
       { type: 'AttrUnquoted', name: 'unquoted', quote: '' },
     ].forEach((testConfig) => {
       it(`should parse ${testConfig.type} attributes`, () => {

--- a/test/html-attributes/fixed.liquid
+++ b/test/html-attributes/fixed.liquid
@@ -160,3 +160,6 @@ printWidth: 1
 
 It should pretty unquoted liquid drop attributes
 <div id="{{ section.id }}--omg"></div>
+
+It should pretty print smart quotes into dumb quotes to prevent copy pasting errors
+<h1 class="section-header__title h2" id="abc"></h1>

--- a/test/html-attributes/index.liquid
+++ b/test/html-attributes/index.liquid
@@ -104,3 +104,6 @@ printWidth: 1
 
 It should pretty unquoted liquid drop attributes
 <div id={{ section.id }}--omg></div>
+
+It should pretty print smart quotes into dumb quotes to prevent copy pasting errors
+<h1 class=“section-header__title h2” id=‘abc’></h1>


### PR DESCRIPTION
e.g. parse the following as though the quotes were the correct ones

```liquid
<h1 class=“section-header__title h2” id=‘abc’></h1>
```

and reprint as dumb quotes

```liquid
<h1 class="section-header__title h2" id="abc"></h1>
```

Fixes #130
