### PR TITLE
Maintain at most 1 newline between Liquid branches

### DIFF
--- a/test/liquid-liquid-tag/fixed.liquid
+++ b/test/liquid-liquid-tag/fixed.liquid
@@ -74,6 +74,7 @@ It should keep at most one empty new line between statements, and strip trailing
     echo foo
 
     echo bar
+
   else
     echo bar
   endif
@@ -82,6 +83,7 @@ It should keep at most one empty new line between statements, and strip trailing
   case foo
     when bar, baz
       echo 'hi'
+
     else
       echo 'no'
   endcase

--- a/test/liquid-liquid-tag/index.liquid
+++ b/test/liquid-liquid-tag/index.liquid
@@ -82,6 +82,7 @@ endif
 case foo
 when bar,baz
 echo 'hi'
+
 else
 echo 'no'
 endcase

--- a/test/liquid-tag-case/fixed.liquid
+++ b/test/liquid-tag-case/fixed.liquid
@@ -42,3 +42,30 @@ It should join args with comma and space
   {% when foo, bar %}
     yum!
 {% endcase %}
+
+It should maintain at most one new line between cases
+{% case foo %}
+  {% when bar %}
+    <div>Something</div>
+
+  {% when baz %}
+    <div>Something else</div>
+{% endcase %}
+
+It should not maintain trailing whitespace in last case and parent
+{% case foo %}
+  {% when bar %}
+    <div>Something</div>
+
+  {% when baz %}
+    <div>Something else</div>
+{% endcase %}
+
+It should not maintain leading whitespace in default branch
+{% case foo %}
+  {% when bar %}
+    <div>Something</div>
+
+  {% when baz %}
+    <div>Something else</div>
+{% endcase %}

--- a/test/liquid-tag-case/index.liquid
+++ b/test/liquid-tag-case/index.liquid
@@ -21,3 +21,34 @@ printWidth: 1
 
 It should join args with comma and space
 {% case candy.type %} {% when foo,bar %} yum! {% endcase %}
+
+It should maintain at most one new line between cases
+{% case foo %}
+  {% when bar %}
+    <div>Something</div>
+
+
+  {% when baz %}
+    <div>Something else</div>
+{% endcase %}
+
+It should not maintain trailing whitespace between last case and parent
+{% case foo %}
+  {% when bar %}
+    <div>Something</div>
+
+  {% when baz %}
+    <div>Something else</div>
+
+
+{% endcase %}
+
+It should not maintain leading whitespace in default branch
+{% case foo %}
+
+  {% when bar %}
+    <div>Something</div>
+
+  {% when baz %}
+    <div>Something else</div>
+{% endcase %}

--- a/test/liquid-tag-if/fixed.liquid
+++ b/test/liquid-tag-if/fixed.liquid
@@ -64,3 +64,38 @@ printWidth: 30
 
 It should be idempotent
 {% if variable >= 1 %} {% endif %}
+
+It should not maintain leading whitespace in default branch
+{% if true %}
+  hello
+{% endif %}
+
+It should maintain at most 1 new line between the default branch and the next
+{% if true %}
+  hello
+
+{% else %}
+  world
+{% endif %}
+
+It should maintain at most 1 new line between the branches
+{% if true %}
+  hello
+
+{% elsif true %}
+  world
+
+{% else %}
+  world
+{% endif %}
+
+It should not maintain trailing newlines between last branch and parent node
+{% if true %}
+  hello
+
+{% elsif true %}
+  world
+
+{% else %}
+  world
+{% endif %}

--- a/test/liquid-tag-if/index.liquid
+++ b/test/liquid-tag-if/index.liquid
@@ -26,3 +26,44 @@ printWidth: 30
 
 It should be idempotent
 {% if variable >= 1 %} {% endif %}
+
+It should not maintain leading whitespace in default branch
+{% if true %}
+
+  hello
+{% endif %}
+
+It should maintain at most 1 new line between the default branch and the next
+{% if true %}
+  hello
+
+
+{% else %}
+  world
+{% endif %}
+
+It should maintain at most 1 new line between the branches
+{% if true %}
+  hello
+
+
+{% elsif true %}
+  world
+
+
+{% else %}
+  world
+{% endif %}
+
+It should not maintain trailing newlines between last branch and parent node
+{% if true %}
+  hello
+
+{% elsif true %}
+  world
+
+{% else %}
+  world
+
+
+{% endif %}


### PR DESCRIPTION
Sometimes, to enhance readability, it is preferabble to have newlines between branches.

Prettier does that for JS `switch` and `case` statements, we now do the same.

```liquid
{% case foo %}
  {% when bar %}
    <div>Something</div>

  {% when baz %}
    <div>Something else</div>
{% endcase %}
```

Fixes #132
