### PR TITLE
Unclosed AST should throw a LiquidHTMLParsingError

### DIFF
--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -476,7 +476,7 @@ describe('Unit: toLiquidHtmlAST', () => {
             },
           },
         ].forEach(({ expression, markup }) => {
-          ast = toLiquidHtmlAST(`{% ${tagName} ${expression} -%}`);
+          ast = toLiquidHtmlAST(`{% ${tagName} ${expression} -%}{% end${tagName} %}`);
           expectPath(ast, 'children.0.type').to.equal('LiquidTag');
           expectPath(ast, 'children.0.name').to.equal(tagName);
           let cursor: any = markup;
@@ -626,6 +626,22 @@ describe('Unit: toLiquidHtmlAST', () => {
         toLiquidHtmlAST(testCase);
         expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
       } catch (e) {
+        expect(e.name).to.eql('LiquidHTMLParsingError');
+        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+      }
+    }
+  });
+
+  it('should throw when trying to end doc with unclosed nodes', () => {
+    const testCases = ['<p><div>', '{% if condition %}', '<script>', '<{{ node_type }}>'];
+    for (const testCase of testCases) {
+      try {
+        toLiquidHtmlAST(testCase);
+        expect(true, `expected ${testCase} to throw LiquidHTMLASTParsingError`).to.be.false;
+      } catch (e) {
+        if (e.name === 'AssertionError') {
+          console.log(e);
+        }
         expect(e.name).to.eql('LiquidHTMLParsingError');
         expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
       }

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -75,6 +75,7 @@ import {
   isLiquidHtmlNode,
   NamedTags,
   NodeTypes,
+  nonTraversableProperties,
   Position,
 } from '~/types';
 import { assertNever, deepGet, dropLast } from '~/utils';
@@ -1479,11 +1480,10 @@ export function walk(
   parentNode?: LiquidHtmlNode,
 ) {
   for (const key of Object.keys(ast)) {
-    if (
-      ['parentNode', 'prev', 'next', 'firstChild', 'lastChild'].includes(key)
-    ) {
+    if (nonTraversableProperties.has(key)) {
       continue;
     }
+
     const value = (ast as any)[key];
     if (Array.isArray(value)) {
       value

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -582,7 +582,7 @@ class ASTBuilder {
     node: ConcreteLiquidTagClose | ConcreteHtmlTagClose,
     nodeType: NodeTypes.LiquidTag | NodeTypes.HtmlElement,
   ) {
-    if (this.parent?.type === NodeTypes.LiquidBranch) {
+    if (isLiquidBranch(this.parent)) {
       this.parent.position.end = node.locStart;
       this.cursor.pop();
       this.cursor.pop();
@@ -593,12 +593,15 @@ class ASTBuilder {
       this.parent?.type !== nodeType
     ) {
       throw new LiquidHTMLASTParsingError(
-        `Attempting to close ${nodeType} '${node.name}' before ${this.parent?.type} '${this.parent?.name}' was closed`,
+        `Attempting to close ${nodeType} '${node.name}' before ${
+          this.parent?.type
+        } '${getName(this.parent)}' was closed`,
         this.source,
         this.parent?.position?.start || 0,
         node.locEnd,
       );
     }
+
     // The parent end is the end of the outer tag.
     this.parent.position.end = node.locEnd;
     this.parent.blockEndPosition = position(node);
@@ -612,6 +615,12 @@ class ASTBuilder {
     this.cursor.pop();
     this.cursor.pop();
   }
+}
+
+function isLiquidBranch(
+  node: LiquidHtmlNode | undefined,
+): node is LiquidBranchNode<any, any> {
+  return !!node && node.type === NodeTypes.LiquidBranch;
 }
 
 function getName(
@@ -819,6 +828,17 @@ export function cstToAst(
         assertNever(node);
       }
     }
+  }
+
+  if (builder.cursor.length !== 0) {
+    throw new LiquidHTMLASTParsingError(
+      `Attempting to end parsing before ${builder.parent?.type} '${getName(
+        builder.parent,
+      )}' was closed`,
+      builder.source,
+      builder.source.length - 1,
+      builder.source.length,
+    );
   }
 
   return builder.ast;

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -22,6 +22,7 @@ import {
   DocumentNode,
   LiquidRawTag,
   AttrEmpty,
+  nonTraversableProperties,
 } from '~/types';
 import { assertNever } from '~/utils';
 
@@ -561,14 +562,6 @@ function printNode(
   }
 }
 
-const ignoredKeys = new Set([
-  'prev',
-  'parentNode',
-  'next',
-  'firstChild',
-  'lastChild',
-]);
-
 export const printerLiquidHtml: Printer<LiquidHtmlNode> & {
   preprocess: any;
 } & { getVisitorKeys: any } = {
@@ -577,7 +570,8 @@ export const printerLiquidHtml: Printer<LiquidHtmlNode> & {
   preprocess,
   getVisitorKeys(node: any, nonTraversableKeys: Set<string>) {
     return Object.keys(node).filter(
-      (key) => !nonTraversableKeys.has(key) && !ignoredKeys.has(key),
+      (key) =>
+        !nonTraversableKeys.has(key) && !nonTraversableProperties.has(key),
     );
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,15 @@ export type LiquidPrinter = (
   args?: LiquidPrinterArgs,
 ) => Doc;
 
+// Those properties create loops that would make walking infinite
+export const nonTraversableProperties = new Set([
+  'parentNode',
+  'prev',
+  'next',
+  'firstChild',
+  'lastChild',
+]);
+
 // This one warrants a bit of an explanation 'cuz it's definitely next
 // level typescript kung-fu shit.
 //

--- a/test/liquid-tag-no-argument/fixed.liquid
+++ b/test/liquid-tag-no-argument/fixed.liquid
@@ -11,7 +11,7 @@ It should strip arguments from javascript tags
 {% endjavascript %}
 
 It should strip arguments from else tags
-{% else %}
+{% if cond %}{% else %}{% endif %}
 
 It should strip arguments from break tags
 {% break %}

--- a/test/liquid-tag-no-argument/index.liquid
+++ b/test/liquid-tag-no-argument/index.liquid
@@ -11,7 +11,7 @@ It should strip arguments from javascript tags
 {% endjavascript %}
 
 It should strip arguments from else tags
-{% else what %}
+{% if cond %}{% else what %}{% endif %}
 
 It should strip arguments from break tags
 {% break what %}


### PR DESCRIPTION
- Refactor duplicated nonTraversableProperties
- Top level unclosed tags should throw errors
