### PR TITLE
Fix parsing error messages

### DIFF
--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -627,6 +627,38 @@ describe('Unit: toLiquidHtmlAST', () => {
         expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
       } catch (e) {
         expect(e.name).to.eql('LiquidHTMLParsingError');
+        expect(e.message).to.match(/Attempting to close \w+ '[^']+' before \w+ '[^']+' was closed/);
+        expect(e.message).not.to.match(/undefined/i);
+        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+      }
+    }
+  });
+
+  it('should throw when closing at the top level', () => {
+    const testCases = ['<a>', '{% if %}'];
+    for (const testCase of testCases) {
+      try {
+        toLiquidHtmlAST(testCase);
+        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+      } catch (e) {
+        expect(e.name).to.eql('LiquidHTMLParsingError');
+        expect(e.message).to.match(/Attempting to end parsing before \w+ '[^']+' was closed/);
+        expect(e.message).not.to.match(/undefined/i);
+        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+      }
+    }
+  });
+
+  it('should throw when forgetting to close', () => {
+    const testCases = ['</a>', '{% endif %}'];
+    for (const testCase of testCases) {
+      try {
+        toLiquidHtmlAST(testCase);
+        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+      } catch (e) {
+        expect(e.name).to.eql('LiquidHTMLParsingError');
+        expect(e.message).to.match(/Attempting to close \w+ '[^']+' before it was opened/);
+        expect(e.message).not.to.match(/undefined/i);
         expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
       }
     }

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -588,16 +588,27 @@ class ASTBuilder {
       this.cursor.pop();
     }
 
+    if (!this.parent) {
+      throw new LiquidHTMLASTParsingError(
+        `Attempting to close ${nodeType} '${getName(
+          node,
+        )}' before it was opened`,
+        this.source,
+        node.locStart,
+        node.locEnd,
+      );
+    }
+
     if (
       getName(this.parent) !== getName(node) ||
-      this.parent?.type !== nodeType
+      this.parent.type !== nodeType
     ) {
       throw new LiquidHTMLASTParsingError(
-        `Attempting to close ${nodeType} '${node.name}' before ${
-          this.parent?.type
+        `Attempting to close ${nodeType} '${getName(node)}' before ${
+          this.parent.type
         } '${getName(this.parent)}' was closed`,
         this.source,
-        this.parent?.position?.start || 0,
+        this.parent.position.start,
         node.locEnd,
       );
     }


### PR DESCRIPTION
Avoid undefined 'undefined' messages as per #138.

Fixes #138
