### PR TITLE
Fix trailing whitespace after opening raw tag breaking formatting

### DIFF
--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -254,9 +254,13 @@ function printNode(
       }
 
       const lines = bodyLines(node.value);
-      const shouldSkipFirstLine =
-        !node.source[node.position.start].match(/\r|\n/);
-      return lines.length > 0 && lines[0].trim() !== ''
+
+      const rawFirstLineIsntIndented = !!node.value
+        .split(/\r?\n/)[0]
+        ?.match(/\S/);
+      const shouldSkipFirstLine = rawFirstLineIsntIndented;
+
+      return lines.length > 0 && lines.find((line) => line.trim() !== '')
         ? join(hardline, reindent(lines, shouldSkipFirstLine))
         : softline;
     }

--- a/src/printer/utils/string.ts
+++ b/src/printer/utils/string.ts
@@ -10,7 +10,7 @@ export const trimEnd = (x: string) => x.trimEnd();
 
 export function bodyLines(str: string): string[] {
   return str
-    .replace(/^\n*|\s*$/g, '') // only want the meat
+    .replace(/^(?: |\t)*(\r?\n)*|\s*$/g, '') // only want the meat
     .split(/\r?\n/);
 }
 

--- a/test/issue-144/fixed.liquid
+++ b/test/issue-144/fixed.liquid
@@ -1,0 +1,5 @@
+it should format as expected when there's whitespace after the opening comment
+{% comment %}
+  This is a comment
+{% endcomment %}
+<p>hello, world!</p>

--- a/test/issue-144/index.liquid
+++ b/test/issue-144/index.liquid
@@ -1,0 +1,5 @@
+it should format as expected when there's whitespace after the opening comment
+{% comment %} 
+This is a comment
+{% endcomment %}
+<p>hello, world!</p>

--- a/test/issue-144/index.spec.ts
+++ b/test/issue-144/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
Turns out our "only want the meat" logic was slightly off and made it so
we printed "" when there was whitespace before the newline character.

Ugh.

Fixes #144
