### PR TITLE
Add support to broken templates in the Liquid parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "yarn build:shims && yarn build:ts && yarn build:standalone",
     "build:shims": "node build/shims.js",
     "build:standalone": "webpack -c webpack.config.js",
-    "build:ts": "tsc -p . && tsc-alias -p tsconfig.json",
+    "build:ts": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "coverage": "nyc yarn test",
     "coverage:json": "nyc --reporter=json yarn test",
     "coverage:lcov": "nyc --reporter=lcov yarn test",

--- a/src/parser/grammar.ts
+++ b/src/parser/grammar.ts
@@ -4,6 +4,7 @@ export const liquidHtmlGrammars = ohm.grammars(
   require('../../grammar/liquid-html.ohm.js'),
 );
 
+export const liquidGrammar = liquidHtmlGrammars['Liquid'];
 export const liquidHtmlGrammar = liquidHtmlGrammars['LiquidHTML'];
 export const liquidStatementsGrammar = liquidHtmlGrammars['LiquidStatement'];
 

--- a/src/parser/stage-1-cst.spec.ts
+++ b/src/parser/stage-1-cst.spec.ts
@@ -1,1046 +1,1117 @@
 import { expect } from 'chai';
-import { LiquidHtmlCST, toLiquidHtmlCST } from '~/parser/stage-1-cst';
+import { LiquidHtmlCST, toLiquidHtmlCST, toLiquidCST, LiquidCST } from '~/parser/stage-1-cst';
 import { BLOCKS, VOID_ELEMENTS } from '~/parser/grammar';
 import { NamedTags } from '~/types';
 import { deepGet } from '~/utils';
 
-describe('Unit: toLiquidHtmlCST(text)', () => {
-  let cst: LiquidHtmlCST;
-
-  describe('Case: HtmlDoctype', () => {
-    it('should basically parse html doctypes', () => {
-      [
-        { text: '<!doctype html>', legacyDoctypeString: null },
-        { text: '<!doctype html >', legacyDoctypeString: null },
-        {
-          text: `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
-           "http://www.w3.org/TR/html4/frameset.dtd">`,
-          legacyDoctypeString: `PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
-           "http://www.w3.org/TR/html4/frameset.dtd"`,
-        },
-      ].forEach(({ text, legacyDoctypeString }) => {
-        cst = toLiquidHtmlCST(text);
-        expectPath(cst, '0.type').to.equal('HtmlDoctype');
-        expectPath(cst, '0.legacyDoctypeString').to.equal(legacyDoctypeString);
-      });
-    });
-  });
-
-  describe('Case: HtmlComment', () => {
-    it('should basically parse html comments', () => {
-      ['<!-- hello world -->'].forEach((text) => {
-        cst = toLiquidHtmlCST(text);
-        expectPath(cst, '0.type').to.equal('HtmlComment');
-        expectPath(cst, '0.body').to.equal('hello world');
-      });
-    });
-  });
-
-  describe('Case: HtmlNode', () => {
-    it('should basically parse open and close tags', () => {
-      ['<div></div>', '<div ></div >'].forEach((text) => {
-        cst = toLiquidHtmlCST(text);
-        expectPath(cst, '0.type').to.eql('HtmlTagOpen');
-        expectPath(cst, '0.name.0.value').to.eql('div');
-        expectPath(cst, '1.type').to.eql('HtmlTagClose');
-        expectPath(cst, '1.name.0.value').to.eql('div');
-      });
-    });
-
-    it('should parse compound tag names', () => {
-      cst = toLiquidHtmlCST('<{{header_type}}--header></{{header_type}}--header>');
-      expectPath(cst, '0.type').to.eql('HtmlTagOpen');
-      expectPath(cst, '0.name.0.type').to.eql('LiquidDrop');
-      expectPath(cst, '0.name.0.markup.type').to.eql('LiquidVariable');
-      expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
-      expectPath(cst, '0.name.1.value').to.eql('--header');
-      expectPath(cst, '1.type').to.eql('HtmlTagClose');
-      expectPath(cst, '1.name.0.type').to.eql('LiquidDrop');
-      expectPath(cst, '1.name.0.markup.type').to.eql('LiquidVariable');
-      expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
-      expectPath(cst, '1.name.1.value').to.eql('--header');
-
-      cst = toLiquidHtmlCST('<header--{{header_type}} ></header--{{header_type}} >');
-      expectPath(cst, '0.type').to.eql('HtmlTagOpen');
-      expectPath(cst, '0.name.0.type').to.eql('TextNode');
-      expectPath(cst, '0.name.0.value').to.eql('header--');
-      expectPath(cst, '0.name.1.type').to.eql('LiquidDrop');
-      expectPath(cst, '0.name.1.markup.type').to.eql('LiquidVariable');
-      expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
-      expectPath(cst, '1.type').to.eql('HtmlTagClose');
-      expectPath(cst, '1.name.0.type').to.eql('TextNode');
-      expectPath(cst, '1.name.0.value').to.eql('header--');
-      expectPath(cst, '1.name.1.type').to.eql('LiquidDrop');
-      expectPath(cst, '1.name.1.markup.type').to.eql('LiquidVariable');
-      expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
-    });
-
-    it('should parse liquid drop tag names', () => {
-      cst = toLiquidHtmlCST('<{{ node_type }}></{{ node_type }}>');
-      expectPath(cst, '0.type').to.equal('HtmlTagOpen');
-      expectPath(cst, '0.name.0.type').to.equal('LiquidDrop');
-      expectPath(cst, '0.name.0.markup.type').to.equal('LiquidVariable');
-      expectPath(cst, '0.name.0.markup.expression.type').to.equal('VariableLookup');
-      expectPath(cst, '0.name.0.markup.expression.name').to.equal('node_type');
-      expectPath(cst, '1.type').to.equal('HtmlTagClose');
-      expectPath(cst, '1.name.0.type').to.equal('LiquidDrop');
-      expectPath(cst, '1.name.0.markup.type').to.equal('LiquidVariable');
-      expectPath(cst, '1.name.0.markup.expression.type').to.equal('VariableLookup');
-      expectPath(cst, '1.name.0.markup.expression.name').to.equal('node_type');
-    });
-
-    it('should parse script and style tags as a dump', () => {
-      cst = toLiquidHtmlCST(
-        '<script>\nconst a = {{ product | json }}\n</script><style>\n#id {}\n</style>',
-      );
-      expectPath(cst, '0.type').to.eql('HtmlRawTag');
-      expectPath(cst, '0.name').to.eql('script');
-      expectPath(cst, '0.body').to.eql('\nconst a = {{ product | json }}\n');
-      expectPath(cst, '1.type').to.eql('HtmlRawTag');
-      expectPath(cst, '1.name').to.eql('style');
-      expectPath(cst, '1.body').to.eql('\n#id {}\n');
-    });
-
-    it('should parse nested svg tags as a dump', () => {
-      const parts = ['<svg disabled a=1>', '<svg><path d=1></svg>', '</svg>'];
-      cst = toLiquidHtmlCST(parts.join(''));
-      expectPath(cst, '0.type').to.eql('HtmlRawTag');
-      expectPath(cst, '0.name').to.eql('svg');
-      expectPath(cst, '0.body').to.eql('<svg><path d=1></svg>');
-      expectPath(cst, '0.attrList.0.name.0.type').to.eql('TextNode');
-      expectPath(cst, '0.attrList.0.name.0.value').to.eql('disabled');
-      expectPath(cst, '0.locStart').to.eql(0);
-      expectPath(cst, '0.locEnd').to.eql(parts[0].length + parts[1].length + parts[2].length);
-      expectPath(cst, '0.blockStartLocStart').to.eql(0);
-      expectPath(cst, '0.blockStartLocEnd').to.eql(parts[0].length);
-      expectPath(cst, '0.blockEndLocStart').to.eql(parts[0].length + parts[1].length);
-      expectPath(cst, '0.blockEndLocEnd').to.eql(
-        parts[0].length + parts[1].length + parts[2].length,
-      );
-    });
-
-    it('should properly return block{Start,End}Loc{Start,End} locations of raw tags', () => {
-      const source = '<script>const a = {{ product | json }}</script>';
-      cst = toLiquidHtmlCST(source);
-      expectPath(cst, '0.type').to.equal('HtmlRawTag');
-      expectPath(cst, '0.blockStartLocStart').to.equal(0);
-      expectPath(cst, '0.blockStartLocEnd').to.equal(source.indexOf('const'));
-      expectPath(cst, '0.blockEndLocStart').to.equal(source.indexOf('</script>'));
-      expectPath(cst, '0.blockEndLocEnd').to.equal(source.length);
-    });
-
-    it('should parse void elements', () => {
-      VOID_ELEMENTS.forEach((voidElementName: any) => {
-        cst = toLiquidHtmlCST(`<${voidElementName} disabled>`);
-        expectPath(cst, '0.type').to.equal('HtmlVoidElement');
-        expectPath(cst, '0.name').to.equal(voidElementName);
-        expectPath(cst, '0.attrList.0.name.0.type').to.eql('TextNode');
-        expectPath(cst, '0.attrList.0.name.0.value').to.eql('disabled');
-      });
-    });
-
-    it('should parse empty attributes', () => {
-      ['<div empty>', '<div empty >', '<div\nempty\n>'].forEach((text) => {
-        cst = toLiquidHtmlCST(text);
-        expectPath(cst, '0.attrList.0.type').to.equal('AttrEmpty');
-        expectPath(cst, '0.attrList.0.name.0.value').to.eql('empty');
-        expectPath(cst, '0.name.attrList.0.value').to.be.undefined;
-      });
-    });
-
+describe('Unit: Stage 1 (CST)', () => {
+  describe('Unit: toLiquidHtmlCST(text) and toLiquidCST(text)', () => {
     [
-      { type: 'AttrSingleQuoted', name: 'single', quote: "'" },
-      { type: 'AttrSingleQuoted', name: 'single', quote: '‘' },
-      { type: 'AttrSingleQuoted', name: 'single', quote: '’' },
-      { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
-      { type: 'AttrDoubleQuoted', name: 'double', quote: '“' },
-      { type: 'AttrDoubleQuoted', name: 'double', quote: '”' },
-      { type: 'AttrUnquoted', name: 'unquoted', quote: '' },
-    ].forEach((testConfig) => {
-      it(`should parse ${testConfig.type} attributes`, () => {
-        [
-          `<div ${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote}>`,
-          `<div ${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote} >`,
-          `<div\n${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote}\n>`,
-        ].forEach((text) => {
-          cst = toLiquidHtmlCST(text);
-          expectPath(cst, '0.attrList.0.type').to.equal(testConfig.type);
-          expectPath(cst, '0.attrList.0.name.0.value').to.eql(testConfig.name);
-          expectPath(cst, '0.attrList.0.value.0.type').to.eql('TextNode');
-          expectPath(cst, '0.attrList.0.value.0.value').to.eql(testConfig.name);
-        });
-      });
+      {
+        title: 'toLiquidHtmlCST(text)',
+        fn: toLiquidHtmlCST,
+      },
+      {
+        title: 'toLiquidCST(text)',
+        fn: toLiquidCST,
+      },
+    ].forEach((testContext) => {
+      let cst: LiquidHtmlCST | LiquidCST;
 
-      if (testConfig.name != 'unquoted') {
-        it(`should accept liquid nodes inside ${testConfig.type}`, () => {
+      const title = testContext.title;
+      const toCST = testContext.fn;
+
+      describe(`${title} - Case: LiquidDrop`, () => {
+        it('should basically parse unparseables', () => {
+          cst = toCST('{{ !-asdl }}{{- !-asdl -}}');
+          expectPath(cst, '0.type').to.equal('LiquidDrop');
+          expectPath(cst, '0.markup').to.equal('!-asdl');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          expectPath(cst, '1.type').to.equal('LiquidDrop');
+          expectPath(cst, '1.markup').to.equal('!-asdl');
+          expectPath(cst, '1.whitespaceStart').to.equal('-');
+          expectPath(cst, '1.whitespaceEnd').to.equal('-');
+        });
+
+        it('should parse strings', () => {
           [
-            `<div ${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote}>`,
-            `<div ${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote} >`,
-            `<div\n${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote}\n>`,
-          ].forEach((text) => {
-            cst = toLiquidHtmlCST(text);
-            expectPath(cst, '0.attrList.0.value.1.type').to.eql('LiquidDrop', text);
+            { expression: `"string o' string"`, value: `string o' string`, single: false },
+            { expression: `'He said: "hi!"'`, value: `He said: "hi!"`, single: true },
+          ].forEach(({ expression, value, single }) => {
+            cst = toLiquidCST(`{{ ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+            expectPath(cst, '0.markup.rawSource').to.equal(expression);
+            expectPath(cst, '0.markup.expression.type').to.equal('String');
+            expectPath(cst, '0.markup.expression.value').to.equal(value);
+            expectPath(cst, '0.markup.expression.single').to.equal(single);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
           });
         });
-      }
 
-      it(`should accept top level liquid nodes that contain ${testConfig.type}`, () => {
-        [
-          `<div {% if A %}${testConfig.name}=${testConfig.quote}https://name${testConfig.quote}{% endif %}>`,
-          `<div {% if A %} ${testConfig.name}=${testConfig.quote}https://name${testConfig.quote} {% endif %}>`,
-          `<div\n{% if A %}\n${testConfig.name}=${testConfig.quote}https://name${testConfig.quote}\n{% endif %}>`,
-        ].forEach((text) => {
-          cst = toLiquidHtmlCST(text);
-          expectPath(cst, '0.attrList.0.type').to.eql('LiquidTagOpen', text);
-          expectPath(cst, '0.attrList.1.type').to.eql(testConfig.type, text);
-          expectPath(cst, '0.attrList.1.value.0.value').to.eql('https://name');
-          expectPath(cst, '0.attrList.2.type').to.eql('LiquidTagClose', text);
+        it('should parse numbers', () => {
+          [
+            { expression: `1`, value: '1' },
+            { expression: `1.02`, value: '1.02' },
+            { expression: `0`, value: '0' },
+            { expression: `-0`, value: '-0' },
+            { expression: `-0.0`, value: '-0.0' },
+          ].forEach(({ expression, value }) => {
+            cst = toLiquidCST(`{{ ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+            expectPath(cst, '0.markup.rawSource').to.equal(expression);
+            expectPath(cst, '0.markup.expression.type').to.equal('Number');
+            expectPath(cst, '0.markup.expression.value').to.equal(value);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          });
         });
-      });
-    });
-  });
 
-  describe('Case: LiquidDrop', () => {
-    it('should basically parse unparseables', () => {
-      cst = toLiquidHtmlCST('{{ !-asdl }}{{- !-asdl -}}');
-      expectPath(cst, '0.type').to.equal('LiquidDrop');
-      expectPath(cst, '0.markup').to.equal('!-asdl');
-      expectPath(cst, '0.whitespaceStart').to.equal(null);
-      expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      expectPath(cst, '1.type').to.equal('LiquidDrop');
-      expectPath(cst, '1.markup').to.equal('!-asdl');
-      expectPath(cst, '1.whitespaceStart').to.equal('-');
-      expectPath(cst, '1.whitespaceEnd').to.equal('-');
-    });
+        it('should parse Liquid literals', () => {
+          [
+            { expression: `nil`, value: null },
+            { expression: `null`, value: null },
+            { expression: `true`, value: true },
+            { expression: `blank`, value: '' },
+            { expression: `empty`, value: '' },
+          ].forEach(({ expression, value }) => {
+            cst = toLiquidCST(`{{ ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
+            expectPath(cst, '0.markup.rawSource').to.equal(expression);
+            expectPath(cst, '0.markup.expression.type').to.equal('LiquidLiteral');
+            expectPath(cst, '0.markup.expression.keyword').to.equal(expression);
+            expectPath(cst, '0.markup.expression.value').to.equal(value);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          });
+        });
 
-    it('should parse strings', () => {
-      [
-        { expression: `"string o' string"`, value: `string o' string`, single: false },
-        { expression: `'He said: "hi!"'`, value: `He said: "hi!"`, single: true },
-      ].forEach(({ expression, value, single }) => {
-        cst = toLiquidHtmlCST(`{{ ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-        expectPath(cst, '0.markup.rawSource').to.equal(expression);
-        expectPath(cst, '0.markup.expression.type').to.equal('String');
-        expectPath(cst, '0.markup.expression.value').to.equal(value);
-        expectPath(cst, '0.markup.expression.single').to.equal(single);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      });
-    });
+        interface Lookup {
+          type: 'VariableLookup';
+          lookups: (string | number | Lookup)[];
+          name: string | undefined;
+        }
 
-    it('should parse numbers', () => {
-      [
-        { expression: `1`, value: '1' },
-        { expression: `1.02`, value: '1.02' },
-        { expression: `0`, value: '0' },
-        { expression: `-0`, value: '-0' },
-        { expression: `-0.0`, value: '-0.0' },
-      ].forEach(({ expression, value }) => {
-        cst = toLiquidHtmlCST(`{{ ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-        expectPath(cst, '0.markup.rawSource').to.equal(expression);
-        expectPath(cst, '0.markup.expression.type').to.equal('Number');
-        expectPath(cst, '0.markup.expression.value').to.equal(value);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      });
-    });
+        it('should parse variable lookups', () => {
+          const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
+            type: 'VariableLookup',
+            name,
+            lookups,
+          });
+          [
+            { expression: `x`, name: 'x', lookups: [] },
+            { expression: `x.y`, name: 'x', lookups: ['y'] },
+            { expression: `x["y"]`, name: 'x', lookups: ['y'] },
+            { expression: `x['y']`, name: 'x', lookups: ['y'] },
+            { expression: `x[1]`, name: 'x', lookups: [1] },
+            { expression: `x.y.z`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `x["y"]["z"]`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `x["y"].z`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `["product"]`, name: null, lookups: ['product'] },
+            { expression: `page.about-us`, name: 'page', lookups: ['about-us'] },
+            { expression: `["x"].y`, name: null, lookups: ['x', 'y'] },
+            { expression: `["x"]["y"]`, name: null, lookups: ['x', 'y'] },
+            { expression: `x[y]`, name: 'x', lookups: [v('y')] },
+            { expression: `x[y.z]`, name: 'x', lookups: [v('y', ['z'])] },
+            { expression: `true_thing`, name: 'true_thing', lookups: [] },
+            { expression: `null_thing`, name: 'null_thing', lookups: [] },
+          ].forEach(({ expression, name, lookups }) => {
+            cst = toLiquidCST(`{{ ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
+            expectPath(cst, '0.markup.rawSource').to.equal(expression);
+            expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
+            expectPath(cst, '0.markup.expression.name').to.equal(name, expression);
+            expectPath(cst, '0.markup.expression.lookups').to.be.an('array');
 
-    it('should parse Liquid literals', () => {
-      [
-        { expression: `nil`, value: null },
-        { expression: `null`, value: null },
-        { expression: `true`, value: true },
-        { expression: `blank`, value: '' },
-        { expression: `empty`, value: '' },
-      ].forEach(({ expression, value }) => {
-        cst = toLiquidHtmlCST(`{{ ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
-        expectPath(cst, '0.markup.rawSource').to.equal(expression);
-        expectPath(cst, '0.markup.expression.type').to.equal('LiquidLiteral');
-        expectPath(cst, '0.markup.expression.keyword').to.equal(expression);
-        expectPath(cst, '0.markup.expression.value').to.equal(value);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      });
-    });
+            lookups.forEach((lookup: string | number | Lookup, i: number) => {
+              switch (typeof lookup) {
+                case 'string': {
+                  expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal('String');
+                  expectPath(cst, `0.markup.expression.lookups.${i}.value`).to.equal(lookup);
+                  break;
+                }
+                case 'number': {
+                  expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal('Number');
+                  expectPath(cst, `0.markup.expression.lookups.${i}.value`).to.equal(
+                    lookup.toString(),
+                  );
+                  break;
+                }
+                default: {
+                  expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal(
+                    'VariableLookup',
+                  );
+                  expectPath(cst, `0.markup.expression.lookups.${i}.name`).to.equal(lookup.name);
+                  lookup.lookups.forEach((val, j) => {
+                    // Being lazy here... Assuming string properties.
+                    expectPath(cst, `0.markup.expression.lookups.${i}.lookups.${j}.type`).to.equal(
+                      'String',
+                    );
+                    expectPath(cst, `0.markup.expression.lookups.${i}.lookups.${j}.value`).to.equal(
+                      val,
+                    );
+                  });
+                  break;
+                }
+              }
+            });
 
-    interface Lookup {
-      type: 'VariableLookup';
-      lookups: (string | number | Lookup)[];
-      name: string | undefined;
-    }
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          });
+        });
 
-    it('should parse variable lookups', () => {
-      const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
-        type: 'VariableLookup',
-        name,
-        lookups,
-      });
-      [
-        { expression: `x`, name: 'x', lookups: [] },
-        { expression: `x.y`, name: 'x', lookups: ['y'] },
-        { expression: `x["y"]`, name: 'x', lookups: ['y'] },
-        { expression: `x['y']`, name: 'x', lookups: ['y'] },
-        { expression: `x[1]`, name: 'x', lookups: [1] },
-        { expression: `x.y.z`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `x["y"]["z"]`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `x["y"].z`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `["product"]`, name: null, lookups: ['product'] },
-        { expression: `page.about-us`, name: 'page', lookups: ['about-us'] },
-        { expression: `["x"].y`, name: null, lookups: ['x', 'y'] },
-        { expression: `["x"]["y"]`, name: null, lookups: ['x', 'y'] },
-        { expression: `x[y]`, name: 'x', lookups: [v('y')] },
-        { expression: `x[y.z]`, name: 'x', lookups: [v('y', ['z'])] },
-        { expression: `true_thing`, name: 'true_thing', lookups: [] },
-        { expression: `null_thing`, name: 'null_thing', lookups: [] },
-      ].forEach(({ expression, name, lookups }) => {
-        cst = toLiquidHtmlCST(`{{ ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
-        expectPath(cst, '0.markup.rawSource').to.equal(expression);
-        expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
-        expectPath(cst, '0.markup.expression.name').to.equal(name, expression);
-        expectPath(cst, '0.markup.expression.lookups').to.be.an('array');
+        it('should parse ranges', () => {
+          [
+            {
+              expression: `(0..5)`,
+              start: { value: '0', type: 'Number' },
+              end: { value: '5', type: 'Number' },
+            },
+            {
+              expression: `( 0 .. 5 )`,
+              start: { value: '0', type: 'Number' },
+              end: { value: '5', type: 'Number' },
+            },
+            {
+              expression: `(true..false)`,
+              start: { value: true, type: 'LiquidLiteral' },
+              end: { value: false, type: 'LiquidLiteral' },
+            },
+          ].forEach(({ expression, start, end }) => {
+            cst = toLiquidCST(`{{ ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
+            expectPath(cst, '0.markup.rawSource').to.equal(expression);
+            expectPath(cst, '0.markup.expression.type').to.equal('Range');
+            expectPath(cst, '0.markup.expression.start.type').to.equal(start.type);
+            expectPath(cst, '0.markup.expression.start.value').to.equal(start.value);
+            expectPath(cst, '0.markup.expression.end.type').to.equal(end.type);
+            expectPath(cst, '0.markup.expression.end.value').to.equal(end.value);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          });
+        });
 
-        lookups.forEach((lookup: string | number | Lookup, i: number) => {
-          switch (typeof lookup) {
-            case 'string': {
-              expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal('String');
-              expectPath(cst, `0.markup.expression.lookups.${i}.value`).to.equal(lookup);
-              break;
-            }
-            case 'number': {
-              expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal('Number');
-              expectPath(cst, `0.markup.expression.lookups.${i}.value`).to.equal(lookup.toString());
-              break;
-            }
-            default: {
-              expectPath(cst, `0.markup.expression.lookups.${i}.type`).to.equal('VariableLookup');
-              expectPath(cst, `0.markup.expression.lookups.${i}.name`).to.equal(lookup.name);
-              lookup.lookups.forEach((val, j) => {
-                // Being lazy here... Assuming string properties.
-                expectPath(cst, `0.markup.expression.lookups.${i}.lookups.${j}.type`).to.equal(
-                  'String',
-                );
-                expectPath(cst, `0.markup.expression.lookups.${i}.lookups.${j}.value`).to.equal(
-                  val,
-                );
-              });
-              break;
-            }
+        it('should parse filters', () => {
+          interface Filter {
+            name: string;
+            args: FilterArgument[];
           }
-        });
+          type FilterArgument = any;
 
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      });
-    });
-
-    it('should parse ranges', () => {
-      [
-        {
-          expression: `(0..5)`,
-          start: { value: '0', type: 'Number' },
-          end: { value: '5', type: 'Number' },
-        },
-        {
-          expression: `( 0 .. 5 )`,
-          start: { value: '0', type: 'Number' },
-          end: { value: '5', type: 'Number' },
-        },
-        {
-          expression: `(true..false)`,
-          start: { value: true, type: 'LiquidLiteral' },
-          end: { value: false, type: 'LiquidLiteral' },
-        },
-      ].forEach(({ expression, start, end }) => {
-        cst = toLiquidHtmlCST(`{{ ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
-        expectPath(cst, '0.markup.rawSource').to.equal(expression);
-        expectPath(cst, '0.markup.expression.type').to.equal('Range');
-        expectPath(cst, '0.markup.expression.start.type').to.equal(start.type);
-        expectPath(cst, '0.markup.expression.start.value').to.equal(start.value);
-        expectPath(cst, '0.markup.expression.end.type').to.equal(end.type);
-        expectPath(cst, '0.markup.expression.end.value').to.equal(end.value);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      });
-    });
-
-    it('should parse filters', () => {
-      interface Filter {
-        name: string;
-        args: FilterArgument[];
-      }
-      type FilterArgument = any;
-
-      const filter = (name: string, args: FilterArgument[] = []): Filter => ({ name, args });
-      const arg = (type: string, value: string) => ({ type, value });
-      const namedArg = (name: string, valueType: string) => ({
-        type: 'NamedArgument',
-        name,
-        valueType,
-      });
-      [
-        { expression: '', filters: [] },
-        { expression: `| filter1`, filters: [filter('filter1')] },
-        { expression: `| filter1 | filter2`, filters: [filter('filter1'), filter('filter2')] },
-        {
-          expression: `| filter1: 'hi', 'there'`,
-          filters: [filter('filter1', [arg('String', 'hi'), arg('String', 'there')])],
-        },
-        {
-          expression: `| filter1: key: value, kind: 'string'`,
-          filters: [
-            filter('filter1', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
-          ],
-        },
-        {
-          expression: `| f1: 'hi', key: (0..1) | f2: key: value, kind: 'string'`,
-          filters: [
-            filter('f1', [arg('String', 'hi'), namedArg('key', 'Range')]),
-            filter('f2', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
-          ],
-        },
-      ].forEach(({ expression, filters }) => {
-        cst = toLiquidHtmlCST(`{{ 'hello' ${expression} }}`);
-        expectPath(cst, '0.type').to.equal('LiquidDrop');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-        expectPath(cst, '0.markup.rawSource').to.equal((`'hello' ` + expression).trimEnd());
-        expectPath(cst, '0.markup.filters').to.exist;
-        expectPath(cst, '0.markup.filters').to.have.lengthOf(filters.length);
-        filters.forEach((filter, i) => {
-          expectPath(cst, `0.markup.filters.${i}`).to.exist;
-          expectPath(cst, `0.markup.filters.${i}.type`).to.equal('LiquidFilter', expression);
-          expectPath(cst, `0.markup.filters.${i}.name`).to.equal(filter.name);
-          expectPath(cst, `0.markup.filters.${i}.args`).to.exist;
-          expectPath(cst, `0.markup.filters.${i}.args`).to.have.lengthOf(
-            filter.args.length,
-            expression,
-          );
-          filter.args.forEach((arg: any, j) => {
-            switch (arg.type) {
-              case 'String': {
-                expectPath(cst, `0.markup.filters.${i}.args.${j}.type`).to.equal('String');
-                expectPath(cst, `0.markup.filters.${i}.args.${j}.value`).to.equal(arg.value);
-                break;
-              }
-              case 'NamedArgument': {
-                expectPath(cst, `0.markup.filters.${i}.args`).to.not.be.empty;
-                expectPath(cst, `0.markup.filters.${i}.args.${j}.type`).to.equal('NamedArgument');
-                expectPath(cst, `0.markup.filters.${i}.args.${j}.name`).to.equal(arg.name);
-                expectPath(cst, `0.markup.filters.${i}.args.${j}.value.type`).to.equal(
-                  arg.valueType,
-                );
-                break;
-              }
-            }
+          const filter = (name: string, args: FilterArgument[] = []): Filter => ({ name, args });
+          const arg = (type: string, value: string) => ({ type, value });
+          const namedArg = (name: string, valueType: string) => ({
+            type: 'NamedArgument',
+            name,
+            valueType,
+          });
+          [
+            { expression: '', filters: [] },
+            { expression: `| filter1`, filters: [filter('filter1')] },
+            { expression: `| filter1 | filter2`, filters: [filter('filter1'), filter('filter2')] },
+            {
+              expression: `| filter1: 'hi', 'there'`,
+              filters: [filter('filter1', [arg('String', 'hi'), arg('String', 'there')])],
+            },
+            {
+              expression: `| filter1: key: value, kind: 'string'`,
+              filters: [
+                filter('filter1', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
+              ],
+            },
+            {
+              expression: `| f1: 'hi', key: (0..1) | f2: key: value, kind: 'string'`,
+              filters: [
+                filter('f1', [arg('String', 'hi'), namedArg('key', 'Range')]),
+                filter('f2', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
+              ],
+            },
+          ].forEach(({ expression, filters }) => {
+            cst = toLiquidCST(`{{ 'hello' ${expression} }}`);
+            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+            expectPath(cst, '0.markup.rawSource').to.equal((`'hello' ` + expression).trimEnd());
+            expectPath(cst, '0.markup.filters').to.exist;
+            expectPath(cst, '0.markup.filters').to.have.lengthOf(filters.length);
+            filters.forEach((filter, i) => {
+              expectPath(cst, `0.markup.filters.${i}`).to.exist;
+              expectPath(cst, `0.markup.filters.${i}.type`).to.equal('LiquidFilter', expression);
+              expectPath(cst, `0.markup.filters.${i}.name`).to.equal(filter.name);
+              expectPath(cst, `0.markup.filters.${i}.args`).to.exist;
+              expectPath(cst, `0.markup.filters.${i}.args`).to.have.lengthOf(
+                filter.args.length,
+                expression,
+              );
+              filter.args.forEach((arg: any, j) => {
+                switch (arg.type) {
+                  case 'String': {
+                    expectPath(cst, `0.markup.filters.${i}.args.${j}.type`).to.equal('String');
+                    expectPath(cst, `0.markup.filters.${i}.args.${j}.value`).to.equal(arg.value);
+                    break;
+                  }
+                  case 'NamedArgument': {
+                    expectPath(cst, `0.markup.filters.${i}.args`).to.not.be.empty;
+                    expectPath(cst, `0.markup.filters.${i}.args.${j}.type`).to.equal(
+                      'NamedArgument',
+                    );
+                    expectPath(cst, `0.markup.filters.${i}.args.${j}.name`).to.equal(arg.name);
+                    expectPath(cst, `0.markup.filters.${i}.args.${j}.value.type`).to.equal(
+                      arg.valueType,
+                    );
+                    break;
+                  }
+                }
+              });
+            });
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal(null);
           });
         });
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal(null);
       });
-    });
-  });
 
-  describe('Case: LiquidTag', () => {
-    it('should parse the liquid liquid tag as a list of tags', () => {
-      [
-        [
-          {
-            expression: `echo "hi"`,
-            type: 'LiquidTag',
-            name: 'echo',
-          },
-          {
-            expression: `
-              comment
-                hello there
-                got you, eh?
-              endcomment`,
-            type: 'LiquidRawTag',
-            name: 'comment',
-          },
-          {
-            expression: `
-              if cond
-            `,
-            type: 'LiquidTagOpen',
-            name: 'if',
-          },
-          {
-            expression: `
-              endif
-            `,
-            type: 'LiquidTagClose',
-            name: 'if',
-          },
-          {
-            expression: `
-              # this is an inline comment
-            `,
-            type: 'LiquidTag',
-            name: '#',
-          },
-        ],
-      ].forEach((expressions) => {
-        cst = toLiquidHtmlCST(`{% liquid \n${expressions.map((x) => x.expression).join('\n')} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('liquid');
-        expressions.forEach(({ type, name }, i) => {
-          expectPath(cst, `0.markup.${i}.type`).to.equal(type);
-          expectPath(cst, `0.markup.${i}.name`).to.equal(name);
-        });
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-
-    it('should support nested comments', () => {
-      const commentBodyContainingNestedComment = `  hello
-      comment tagMarkup
-        nested comment body
-      endcomment
-      outer comment body`;
-      const statementSep = '\n  ';
-      const commentExpr = ['comment', commentBodyContainingNestedComment, 'endcomment'].join(
-        statementSep,
-      );
-      const testStr = ['{% liquid', commentExpr, '%}'].join('\n');
-      cst = toLiquidHtmlCST(testStr);
-      expectPath(cst, '0.type').to.equal('LiquidTag');
-      expectPath(cst, '0.name').to.equal('liquid');
-      expectPath(cst, '0.markup.0.type').to.equal('LiquidRawTag');
-      expectPath(cst, '0.markup.0.name').to.equal('comment');
-      expectPath(cst, '0.markup.0.body').to.equal(
-        // We don't want the newline but we do want the leading spaces
-        // The reason we want that is because we want this to behave like LiquidRawTag
-        statementSep.slice(1) + commentBodyContainingNestedComment + statementSep,
-      );
-      expectPath(cst, '0.markup.0.whitespaceStart').to.equal('');
-      expectPath(cst, '0.markup.0.whitespaceEnd').to.equal('');
-      expectPath(cst, '0.markup.0.delimiterWhitespaceStart').to.equal('');
-      expectPath(cst, '0.markup.0.delimiterWhitespaceEnd').to.equal('');
-
-      const liquidStatementOffset = '{% liquid\n'.length;
-      expectPath(cst, '0.markup.0.blockStartLocStart').to.equal(liquidStatementOffset);
-      expectPath(cst, '0.markup.0.blockStartLocEnd').to.equal(
-        liquidStatementOffset + 'comment'.length,
-      );
-      expectPath(cst, '0.markup.0.blockEndLocStart').to.equal(
-        testStr.length - 'endcomment\n%}'.length,
-      );
-      expectPath(cst, '0.markup.0.blockEndLocEnd').to.equal(testStr.length - '\n%}'.length);
-    });
-
-    it('should parse the echo tag as variables', () => {
-      [
-        { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
-        { expression: `x | f`, expressionType: 'VariableLookup', filters: ['f'] },
-      ].forEach(({ expression, expressionType, expressionValue, filters }) => {
-        cst = toLiquidHtmlCST(`{% echo ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('echo');
-        expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-        expectPath(cst, '0.markup.expression.type').to.equal(expressionType);
-        if (expressionValue) {
-          expectPath(cst, '0.markup.expression.value').to.equal(expressionValue);
-        }
-        expectPath(cst, '0.markup.filters').to.have.lengthOf(filters.length);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-
-    it('should parse the assign tag as assign markup + liquid variable', () => {
-      [
-        {
-          expression: `x = "hi"`,
-          name: 'x',
-          expressionType: 'String',
-          expressionValue: 'hi',
-          filters: [],
-        },
-        { expression: `z = y | f`, name: 'z', expressionType: 'VariableLookup', filters: ['f'] },
-      ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
-        cst = toLiquidHtmlCST(`{% assign ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('assign');
-        expectPath(cst, '0.markup.type').to.equal('AssignMarkup');
-        expectPath(cst, '0.markup.name').to.equal(name);
-        expectPath(cst, '0.markup.value.expression.type').to.equal(expressionType);
-        if (expressionValue) {
-          expectPath(cst, '0.markup.value.expression.value').to.equal(expressionValue);
-        }
-        expectPath(cst, '0.markup.value.filters').to.have.lengthOf(filters.length);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-
-    it('should parse the cycle tag as cycle markup', () => {
-      [
-        {
-          expression: `a, "string", 10`,
-          groupName: null,
-          args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
-        },
-        {
-          expression: `var: a, "string", 10`,
-          groupName: { type: 'VariableLookup' },
-          args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
-        },
-      ].forEach(({ expression, groupName, args }) => {
-        cst = toLiquidHtmlCST(`{% cycle ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('cycle');
-        expectPath(cst, '0.markup.type').to.equal('CycleMarkup');
-        if (groupName) {
-          expectPath(cst, '0.markup.groupName.type').to.equal(groupName.type);
-        } else {
-          expectPath(cst, '0.markup.groupName').to.equal(null);
-        }
-        expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
-        args.forEach((arg, i) => {
-          expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
-        });
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-
-    it('should parse the render tag', () => {
-      [
-        {
-          expression: `"snippet"`,
-          snippetType: 'String',
-          alias: null,
-          renderVariableExpression: null,
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" as foo`,
-          snippetType: 'String',
-          alias: 'foo',
-          renderVariableExpression: null,
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" with "string" as foo`,
-          snippetType: 'String',
-          alias: 'foo',
-          renderVariableExpression: {
-            kind: 'with',
-            name: {
-              type: 'String',
-            },
-          },
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" for products as product`,
-          snippetType: 'String',
-          alias: 'product',
-          renderVariableExpression: {
-            kind: 'for',
-            name: {
-              type: 'VariableLookup',
-            },
-          },
-          namedArguments: [],
-        },
-        {
-          expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
-          snippetType: 'VariableLookup',
-          alias: 'foo',
-          renderVariableExpression: {
-            kind: 'with',
-            name: {
-              type: 'String',
-            },
-          },
-          namedArguments: [
-            { name: 'key1', valueType: 'VariableLookup' },
-            { name: 'key2', valueType: 'String' },
-          ],
-        },
-      ].forEach(({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
-        cst = toLiquidHtmlCST(`{% render ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('render');
-        expectPath(cst, '0.markup.type').to.equal('RenderMarkup');
-        expectPath(cst, '0.markup.snippet.type').to.equal(snippetType);
-        if (renderVariableExpression) {
-          expectPath(cst, '0.markup.variable.type').to.equal('RenderVariableExpression');
-          expectPath(cst, '0.markup.variable.kind').to.equal(renderVariableExpression.kind);
-          expectPath(cst, '0.markup.variable.name.type').to.equal(
-            renderVariableExpression.name.type,
-          );
-        } else {
-          expectPath(cst, '0.markup.variable').to.equal(null);
-        }
-        expectPath(cst, '0.markup.alias').to.equal(alias);
-        expectPath(cst, '0.markup.args').to.have.lengthOf(namedArguments.length);
-        namedArguments.forEach(({ name, valueType }, i) => {
-          expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
-          expectPath(cst, `0.markup.args.${i}.name`).to.equal(name);
-          expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(valueType);
-        });
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-  });
-
-  describe('Case: LiquidTagOpen', () => {
-    it('should parse the form tag open markup as arguments', () => {
-      [
-        { expression: `product`, args: [{ type: 'VariableLookup' }] },
-        { expression: `"product"`, args: [{ type: 'String' }] },
-      ].forEach(({ expression, args }) => {
-        cst = toLiquidHtmlCST(`{% form ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-        expectPath(cst, '0.name').to.equal('form');
-        expectPath(cst, '0.markup').to.have.lengthOf(args.length, expression);
-        args.forEach((arg, i) => {
-          expectPath(cst, `0.markup.${i}.type`).to.equal(arg.type);
-        });
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      });
-    });
-
-    it('should parse the for and tablerow tags open markup as ForMarkup', () => {
-      ['for', 'tablerow'].forEach((tagName) => {
-        [
-          {
-            expression: `product in all_products`,
-            variableName: 'product',
-            collection: { type: 'VariableLookup' },
-            reversed: null,
-            args: [],
-          },
-          {
-            expression: `i in (0..x)`,
-            variableName: 'i',
-            collection: { type: 'Range' },
-            reversed: null,
-            args: [],
-          },
-          {
-            expression: `product in all_products reversed`,
-            variableName: 'product',
-            collection: { type: 'VariableLookup' },
-            reversed: 'reversed',
-            args: [],
-          },
-          {
-            expression: `product in all_products limit: 10`,
-            variableName: 'product',
-            collection: { type: 'VariableLookup' },
-            reversed: null,
-            args: [{ type: 'NamedArgument', name: 'limit', value: { type: 'Number' } }],
-          },
-          {
-            expression: `product in all_products reversed limit: 10 offset:var`,
-            variableName: 'product',
-            collection: { type: 'VariableLookup' },
-            reversed: 'reversed',
-            args: [
-              { type: 'NamedArgument', name: 'limit', value: { type: 'Number' } },
-              { type: 'NamedArgument', name: 'offset', value: { type: 'VariableLookup' } },
-            ],
-          },
-        ].forEach(({ expression, variableName, collection, reversed, args }) => {
-          cst = toLiquidHtmlCST(`{% ${tagName} ${expression} -%}`);
-          expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-          expectPath(cst, '0.name').to.equal(tagName);
-          expectPath(cst, '0.markup.type').to.equal('ForMarkup');
-          expectPath(cst, '0.markup.variableName').to.equal(variableName);
-          expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
-          expectPath(cst, '0.markup.reversed').to.equal(reversed);
-          expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
-          args.forEach((arg, i) => {
-            expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
-            expectPath(cst, `0.markup.args.${i}.name`).to.equal(arg.name);
-            expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.value.type);
-          });
-          expectPath(cst, '0.whitespaceEnd').to.equal('-');
-        });
-      });
-    });
-
-    it('should parse case arguments as a singular liquid expression', () => {
-      [
-        { expression: `"string"`, type: 'String' },
-        { expression: `var.lookup`, type: 'VariableLookup' },
-      ].forEach(({ expression, type }) => {
-        cst = toLiquidHtmlCST(`{% case ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-        expectPath(cst, '0.name').to.equal('case');
-        expectPath(cst, '0.markup.type').to.equal(type);
-      });
-    });
-
-    it('should parse capture arguments as a singular liquid variable lookup', () => {
-      [{ expression: `var`, type: 'VariableLookup' }].forEach(({ expression, type }) => {
-        cst = toLiquidHtmlCST(`{% capture ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-        expectPath(cst, '0.name').to.equal('capture');
-        expectPath(cst, '0.markup.type').to.equal(type);
-      });
-    });
-
-    it('should parse when arguments as an array of liquid expressions', () => {
-      [
-        { expression: `"string"`, args: [{ type: 'String' }] },
-        {
-          expression: `"string", var.lookup`,
-          args: [{ type: 'String' }, { type: 'VariableLookup' }],
-        },
-        {
-          expression: `"string" or var.lookup`,
-          args: [{ type: 'String' }, { type: 'VariableLookup' }],
-        },
-      ].forEach(({ expression, args }) => {
-        cst = toLiquidHtmlCST(`{% when ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTag');
-        expectPath(cst, '0.name').to.equal('when');
-        expectPath(cst, '0.markup').to.have.lengthOf(args.length);
-        args.forEach((arg, i) => {
-          expectPath(cst, `0.markup.${i}.type`).to.equal(arg.type);
-        });
-      });
-    });
-
-    it('should parse the paginate tag open markup as arguments', () => {
-      [
-        {
-          expression: `collection.products by 50`,
-          collection: { type: 'VariableLookup' },
-          pageSize: { type: 'Number' },
-        },
-        {
-          expression: `collection.products by setting.value`,
-          collection: { type: 'VariableLookup' },
-          pageSize: { type: 'VariableLookup' },
-        },
-        {
-          expression: `collection.products by setting.value window_size: 2`,
-          collection: { type: 'VariableLookup' },
-          pageSize: { type: 'VariableLookup' },
-          args: [{ type: 'Number' }],
-        },
-        {
-          expression: `collection.products by setting.value, window_size: 2`,
-          collection: { type: 'VariableLookup' },
-          pageSize: { type: 'VariableLookup' },
-          args: [{ type: 'Number' }],
-        },
-      ].forEach(({ expression, collection, pageSize, args }) => {
-        cst = toLiquidHtmlCST(`{% paginate ${expression} -%}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen');
-        expectPath(cst, '0.name').to.equal('paginate');
-        expectPath(cst, '0.markup.type').to.equal('PaginateMarkup');
-        expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
-        expectPath(cst, '0.markup.pageSize.type').to.equal(pageSize.type);
-        if (args) {
-          expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
-          args.forEach((arg, i) => {
-            expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
-            expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.type);
-          });
-        } else {
-          expectPath(cst, '0.markup.args').to.have.lengthOf(0);
-        }
-      });
-    });
-
-    it('should parse the if, unless and elsif tag arguments as a list of conditions', () => {
-      ['if', 'unless', 'elsif'].forEach((tagName) => {
-        [
-          {
-            expression: 'a',
-            conditions: [{ relation: null, conditional: { type: 'VariableLookup' } }],
-          },
-          {
-            expression: 'a and "string"',
-            conditions: [
-              { relation: null, conditional: { type: 'VariableLookup' } },
-              { relation: 'and', conditional: { type: 'String' } },
-            ],
-          },
-          {
-            expression: 'a and "string" or a<1',
-            conditions: [
-              { relation: null, conditional: { type: 'VariableLookup' } },
-              { relation: 'and', conditional: { type: 'String' } },
+      describe(`${title} - Case: LiquidTag`, () => {
+        it('should parse the liquid liquid tag as a list of tags', () => {
+          [
+            [
               {
-                relation: 'or',
-                conditional: {
-                  type: 'Comparison',
-                  comparator: '<',
-                  left: { type: 'VariableLookup' },
-                  right: { type: 'Number' },
-                },
+                expression: `echo "hi"`,
+                type: 'LiquidTag',
+                name: 'echo',
+              },
+              {
+                expression: `
+                comment
+                  hello there
+                  got you, eh?
+                endcomment`,
+                type: 'LiquidRawTag',
+                name: 'comment',
+              },
+              {
+                expression: `
+                if cond
+              `,
+                type: 'LiquidTagOpen',
+                name: 'if',
+              },
+              {
+                expression: `
+                endif
+              `,
+                type: 'LiquidTagClose',
+                name: 'if',
+              },
+              {
+                expression: `
+                # this is an inline comment
+              `,
+                type: 'LiquidTag',
+                name: '#',
               },
             ],
-          },
-        ].forEach(({ expression, conditions }) => {
-          cst = toLiquidHtmlCST(`{% ${tagName} ${expression} -%}`);
-          expectPath(cst, '0.type').to.equal(tagName === 'elsif' ? 'LiquidTag' : 'LiquidTagOpen');
-          expectPath(cst, '0.name').to.equal(tagName);
-          expectPath(cst, '0.markup').to.have.lengthOf(conditions.length);
-          conditions.forEach(({ relation, conditional }, i) => {
-            expectPath(cst, `0.markup.${i}.type`).to.equal('Condition');
-            expectPath(cst, `0.markup.${i}.relation`).to.equal(relation);
-            expectPath(cst, `0.markup.${i}.expression.type`).to.equal(conditional.type);
-            if (conditional.type === 'Comparison') {
-              expectPath(cst, `0.markup.${i}.expression.comparator`).to.equal(
-                conditional.comparator,
-              );
-              expectPath(cst, `0.markup.${i}.expression.left.type`).to.equal(conditional.left.type);
-              expectPath(cst, `0.markup.${i}.expression.right.type`).to.equal(
-                conditional.right.type,
-              );
+          ].forEach((expressions) => {
+            cst = toCST(`{% liquid \n${expressions.map((x) => x.expression).join('\n')} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTag');
+            expectPath(cst, '0.name').to.equal('liquid');
+            expressions.forEach(({ type, name }, i) => {
+              expectPath(cst, `0.markup.${i}.type`).to.equal(type);
+              expectPath(cst, `0.markup.${i}.name`).to.equal(name);
+            });
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          });
+        });
+
+        it('should support nested comments', () => {
+          const commentBodyContainingNestedComment = `  hello
+        comment tagMarkup
+          nested comment body
+        endcomment
+        outer comment body`;
+          const statementSep = '\n  ';
+          const commentExpr = ['comment', commentBodyContainingNestedComment, 'endcomment'].join(
+            statementSep,
+          );
+          const testStr = ['{% liquid', commentExpr, '%}'].join('\n');
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.name').to.equal('liquid');
+          expectPath(cst, '0.markup.0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.markup.0.name').to.equal('comment');
+          expectPath(cst, '0.markup.0.body').to.equal(
+            // We don't want the newline but we do want the leading spaces
+            // The reason we want that is because we want this to behave like LiquidRawTag
+            statementSep.slice(1) + commentBodyContainingNestedComment + statementSep,
+          );
+          expectPath(cst, '0.markup.0.whitespaceStart').to.equal('');
+          expectPath(cst, '0.markup.0.whitespaceEnd').to.equal('');
+          expectPath(cst, '0.markup.0.delimiterWhitespaceStart').to.equal('');
+          expectPath(cst, '0.markup.0.delimiterWhitespaceEnd').to.equal('');
+
+          const liquidStatementOffset = '{% liquid\n'.length;
+          expectPath(cst, '0.markup.0.blockStartLocStart').to.equal(liquidStatementOffset);
+          expectPath(cst, '0.markup.0.blockStartLocEnd').to.equal(
+            liquidStatementOffset + 'comment'.length,
+          );
+          expectPath(cst, '0.markup.0.blockEndLocStart').to.equal(
+            testStr.length - 'endcomment\n%}'.length,
+          );
+          expectPath(cst, '0.markup.0.blockEndLocEnd').to.equal(testStr.length - '\n%}'.length);
+        });
+
+        it('should parse the echo tag as variables', () => {
+          [
+            { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
+            { expression: `x | f`, expressionType: 'VariableLookup', filters: ['f'] },
+          ].forEach(({ expression, expressionType, expressionValue, filters }) => {
+            cst = toCST(`{% echo ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTag');
+            expectPath(cst, '0.name').to.equal('echo');
+            expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+            expectPath(cst, '0.markup.expression.type').to.equal(expressionType);
+            if (expressionValue) {
+              expectPath(cst, '0.markup.expression.value').to.equal(expressionValue);
             }
+            expectPath(cst, '0.markup.filters').to.have.lengthOf(filters.length);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          });
+        });
+
+        it('should parse the assign tag as assign markup + liquid variable', () => {
+          [
+            {
+              expression: `x = "hi"`,
+              name: 'x',
+              expressionType: 'String',
+              expressionValue: 'hi',
+              filters: [],
+            },
+            {
+              expression: `z = y | f`,
+              name: 'z',
+              expressionType: 'VariableLookup',
+              filters: ['f'],
+            },
+          ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
+            cst = toCST(`{% assign ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTag');
+            expectPath(cst, '0.name').to.equal('assign');
+            expectPath(cst, '0.markup.type').to.equal('AssignMarkup');
+            expectPath(cst, '0.markup.name').to.equal(name);
+            expectPath(cst, '0.markup.value.expression.type').to.equal(expressionType);
+            if (expressionValue) {
+              expectPath(cst, '0.markup.value.expression.value').to.equal(expressionValue);
+            }
+            expectPath(cst, '0.markup.value.filters').to.have.lengthOf(filters.length);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          });
+        });
+
+        it('should parse the cycle tag as cycle markup', () => {
+          [
+            {
+              expression: `a, "string", 10`,
+              groupName: null,
+              args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
+            },
+            {
+              expression: `var: a, "string", 10`,
+              groupName: { type: 'VariableLookup' },
+              args: [{ type: 'VariableLookup' }, { type: 'String' }, { type: 'Number' }],
+            },
+          ].forEach(({ expression, groupName, args }) => {
+            cst = toCST(`{% cycle ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTag');
+            expectPath(cst, '0.name').to.equal('cycle');
+            expectPath(cst, '0.markup.type').to.equal('CycleMarkup');
+            if (groupName) {
+              expectPath(cst, '0.markup.groupName.type').to.equal(groupName.type);
+            } else {
+              expectPath(cst, '0.markup.groupName').to.equal(null);
+            }
+            expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+            args.forEach((arg, i) => {
+              expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
+            });
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          });
+        });
+
+        it('should parse the render tag', () => {
+          [
+            {
+              expression: `"snippet"`,
+              snippetType: 'String',
+              alias: null,
+              renderVariableExpression: null,
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" as foo`,
+              snippetType: 'String',
+              alias: 'foo',
+              renderVariableExpression: null,
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" with "string" as foo`,
+              snippetType: 'String',
+              alias: 'foo',
+              renderVariableExpression: {
+                kind: 'with',
+                name: {
+                  type: 'String',
+                },
+              },
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" for products as product`,
+              snippetType: 'String',
+              alias: 'product',
+              renderVariableExpression: {
+                kind: 'for',
+                name: {
+                  type: 'VariableLookup',
+                },
+              },
+              namedArguments: [],
+            },
+            {
+              expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
+              snippetType: 'VariableLookup',
+              alias: 'foo',
+              renderVariableExpression: {
+                kind: 'with',
+                name: {
+                  type: 'String',
+                },
+              },
+              namedArguments: [
+                { name: 'key1', valueType: 'VariableLookup' },
+                { name: 'key2', valueType: 'String' },
+              ],
+            },
+          ].forEach(
+            ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
+              cst = toCST(`{% render ${expression} -%}`);
+              expectPath(cst, '0.type').to.equal('LiquidTag');
+              expectPath(cst, '0.name').to.equal('render');
+              expectPath(cst, '0.markup.type').to.equal('RenderMarkup');
+              expectPath(cst, '0.markup.snippet.type').to.equal(snippetType);
+              if (renderVariableExpression) {
+                expectPath(cst, '0.markup.variable.type').to.equal('RenderVariableExpression');
+                expectPath(cst, '0.markup.variable.kind').to.equal(renderVariableExpression.kind);
+                expectPath(cst, '0.markup.variable.name.type').to.equal(
+                  renderVariableExpression.name.type,
+                );
+              } else {
+                expectPath(cst, '0.markup.variable').to.equal(null);
+              }
+              expectPath(cst, '0.markup.alias').to.equal(alias);
+              expectPath(cst, '0.markup.args').to.have.lengthOf(namedArguments.length);
+              namedArguments.forEach(({ name, valueType }, i) => {
+                expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
+                expectPath(cst, `0.markup.args.${i}.name`).to.equal(name);
+                expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(valueType);
+              });
+              expectPath(cst, '0.whitespaceStart').to.equal(null);
+              expectPath(cst, '0.whitespaceEnd').to.equal('-');
+            },
+          );
+        });
+      });
+
+      describe(`${title} - Case: LiquidTagOpen`, () => {
+        it('should parse the form tag open markup as arguments', () => {
+          [
+            { expression: `product`, args: [{ type: 'VariableLookup' }] },
+            { expression: `"product"`, args: [{ type: 'String' }] },
+          ].forEach(({ expression, args }) => {
+            cst = toCST(`{% form ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+            expectPath(cst, '0.name').to.equal('form');
+            expectPath(cst, '0.markup').to.have.lengthOf(args.length, expression);
+            args.forEach((arg, i) => {
+              expectPath(cst, `0.markup.${i}.type`).to.equal(arg.type);
+            });
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          });
+        });
+
+        it('should parse the for and tablerow tags open markup as ForMarkup', () => {
+          ['for', 'tablerow'].forEach((tagName) => {
+            [
+              {
+                expression: `product in all_products`,
+                variableName: 'product',
+                collection: { type: 'VariableLookup' },
+                reversed: null,
+                args: [],
+              },
+              {
+                expression: `i in (0..x)`,
+                variableName: 'i',
+                collection: { type: 'Range' },
+                reversed: null,
+                args: [],
+              },
+              {
+                expression: `product in all_products reversed`,
+                variableName: 'product',
+                collection: { type: 'VariableLookup' },
+                reversed: 'reversed',
+                args: [],
+              },
+              {
+                expression: `product in all_products limit: 10`,
+                variableName: 'product',
+                collection: { type: 'VariableLookup' },
+                reversed: null,
+                args: [{ type: 'NamedArgument', name: 'limit', value: { type: 'Number' } }],
+              },
+              {
+                expression: `product in all_products reversed limit: 10 offset:var`,
+                variableName: 'product',
+                collection: { type: 'VariableLookup' },
+                reversed: 'reversed',
+                args: [
+                  { type: 'NamedArgument', name: 'limit', value: { type: 'Number' } },
+                  { type: 'NamedArgument', name: 'offset', value: { type: 'VariableLookup' } },
+                ],
+              },
+            ].forEach(({ expression, variableName, collection, reversed, args }) => {
+              cst = toCST(`{% ${tagName} ${expression} -%}`);
+              expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+              expectPath(cst, '0.name').to.equal(tagName);
+              expectPath(cst, '0.markup.type').to.equal('ForMarkup');
+              expectPath(cst, '0.markup.variableName').to.equal(variableName);
+              expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
+              expectPath(cst, '0.markup.reversed').to.equal(reversed);
+              expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+              args.forEach((arg, i) => {
+                expectPath(cst, `0.markup.args.${i}.type`).to.equal(arg.type);
+                expectPath(cst, `0.markup.args.${i}.name`).to.equal(arg.name);
+                expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.value.type);
+              });
+              expectPath(cst, '0.whitespaceEnd').to.equal('-');
+            });
+          });
+        });
+
+        it('should parse case arguments as a singular liquid expression', () => {
+          [
+            { expression: `"string"`, type: 'String' },
+            { expression: `var.lookup`, type: 'VariableLookup' },
+          ].forEach(({ expression, type }) => {
+            cst = toCST(`{% case ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+            expectPath(cst, '0.name').to.equal('case');
+            expectPath(cst, '0.markup.type').to.equal(type);
+          });
+        });
+
+        it('should parse capture arguments as a singular liquid variable lookup', () => {
+          [{ expression: `var`, type: 'VariableLookup' }].forEach(({ expression, type }) => {
+            cst = toCST(`{% capture ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+            expectPath(cst, '0.name').to.equal('capture');
+            expectPath(cst, '0.markup.type').to.equal(type);
+          });
+        });
+
+        it('should parse when arguments as an array of liquid expressions', () => {
+          [
+            { expression: `"string"`, args: [{ type: 'String' }] },
+            {
+              expression: `"string", var.lookup`,
+              args: [{ type: 'String' }, { type: 'VariableLookup' }],
+            },
+            {
+              expression: `"string" or var.lookup`,
+              args: [{ type: 'String' }, { type: 'VariableLookup' }],
+            },
+          ].forEach(({ expression, args }) => {
+            cst = toCST(`{% when ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTag');
+            expectPath(cst, '0.name').to.equal('when');
+            expectPath(cst, '0.markup').to.have.lengthOf(args.length);
+            args.forEach((arg, i) => {
+              expectPath(cst, `0.markup.${i}.type`).to.equal(arg.type);
+            });
+          });
+        });
+
+        it('should parse the paginate tag open markup as arguments', () => {
+          [
+            {
+              expression: `collection.products by 50`,
+              collection: { type: 'VariableLookup' },
+              pageSize: { type: 'Number' },
+            },
+            {
+              expression: `collection.products by setting.value`,
+              collection: { type: 'VariableLookup' },
+              pageSize: { type: 'VariableLookup' },
+            },
+            {
+              expression: `collection.products by setting.value window_size: 2`,
+              collection: { type: 'VariableLookup' },
+              pageSize: { type: 'VariableLookup' },
+              args: [{ type: 'Number' }],
+            },
+            {
+              expression: `collection.products by setting.value, window_size: 2`,
+              collection: { type: 'VariableLookup' },
+              pageSize: { type: 'VariableLookup' },
+              args: [{ type: 'Number' }],
+            },
+          ].forEach(({ expression, collection, pageSize, args }) => {
+            cst = toCST(`{% paginate ${expression} -%}`);
+            expectPath(cst, '0.type').to.equal('LiquidTagOpen');
+            expectPath(cst, '0.name').to.equal('paginate');
+            expectPath(cst, '0.markup.type').to.equal('PaginateMarkup');
+            expectPath(cst, '0.markup.collection.type').to.equal(collection.type);
+            expectPath(cst, '0.markup.pageSize.type').to.equal(pageSize.type);
+            if (args) {
+              expectPath(cst, '0.markup.args').to.have.lengthOf(args.length);
+              args.forEach((arg, i) => {
+                expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
+                expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(arg.type);
+              });
+            } else {
+              expectPath(cst, '0.markup.args').to.have.lengthOf(0);
+            }
+          });
+        });
+
+        it('should parse the if, unless and elsif tag arguments as a list of conditions', () => {
+          ['if', 'unless', 'elsif'].forEach((tagName) => {
+            [
+              {
+                expression: 'a',
+                conditions: [{ relation: null, conditional: { type: 'VariableLookup' } }],
+              },
+              {
+                expression: 'a and "string"',
+                conditions: [
+                  { relation: null, conditional: { type: 'VariableLookup' } },
+                  { relation: 'and', conditional: { type: 'String' } },
+                ],
+              },
+              {
+                expression: 'a and "string" or a<1',
+                conditions: [
+                  { relation: null, conditional: { type: 'VariableLookup' } },
+                  { relation: 'and', conditional: { type: 'String' } },
+                  {
+                    relation: 'or',
+                    conditional: {
+                      type: 'Comparison',
+                      comparator: '<',
+                      left: { type: 'VariableLookup' },
+                      right: { type: 'Number' },
+                    },
+                  },
+                ],
+              },
+            ].forEach(({ expression, conditions }) => {
+              cst = toCST(`{% ${tagName} ${expression} -%}`);
+              expectPath(cst, '0.type').to.equal(
+                tagName === 'elsif' ? 'LiquidTag' : 'LiquidTagOpen',
+              );
+              expectPath(cst, '0.name').to.equal(tagName);
+              expectPath(cst, '0.markup').to.have.lengthOf(conditions.length);
+              conditions.forEach(({ relation, conditional }, i) => {
+                expectPath(cst, `0.markup.${i}.type`).to.equal('Condition');
+                expectPath(cst, `0.markup.${i}.relation`).to.equal(relation);
+                expectPath(cst, `0.markup.${i}.expression.type`).to.equal(conditional.type);
+                if (conditional.type === 'Comparison') {
+                  expectPath(cst, `0.markup.${i}.expression.comparator`).to.equal(
+                    conditional.comparator,
+                  );
+                  expectPath(cst, `0.markup.${i}.expression.left.type`).to.equal(
+                    conditional?.left?.type,
+                  );
+                  expectPath(cst, `0.markup.${i}.expression.right.type`).to.equal(
+                    conditional?.right?.type,
+                  );
+                }
+              });
+            });
+          });
+        });
+      });
+
+      describe(`${title} - Case: LiquidNode`, () => {
+        it('should parse raw tags', () => {
+          ['style', 'raw'].forEach((raw) => {
+            cst = toCST(`{% ${raw} -%}<div>{%- end${raw} %}`);
+            expectPath(cst, '0.type').to.equal('LiquidRawTag');
+            expectPath(cst, '0.body').to.equal('<div>');
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+            expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
+            expectPath(cst, '0.delimiterWhitespaceEnd').to.equal(null);
+          });
+        });
+
+        it('should properly return block{Start,End}Loc{Start,End} locations of raw tags', () => {
+          const source = '{% raw -%}<div>{%- endraw %}';
+          cst = toCST(source);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.body').to.equal('<div>');
+          expectPath(cst, '0.blockStartLocStart').to.equal(0);
+          expectPath(cst, '0.blockStartLocEnd').to.equal(source.indexOf('<'));
+          expectPath(cst, '0.blockEndLocStart').to.equal(source.indexOf('>') + 1);
+          expectPath(cst, '0.blockEndLocEnd').to.equal(source.length);
+          expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
+          expectPath(cst, '0.delimiterWhitespaceEnd').to.equal(null);
+        });
+
+        it('should basically parse liquid tags', () => {
+          cst = toCST('{%   unknown x = 1 %}{% if hi -%}{%- endif %}');
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.name').to.equal('unknown');
+          expectPath(cst, '0.markup').to.equal('x = 1');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.whitespaceEnd').to.equal(null);
+          expectPath(cst, '1.type').to.equal('LiquidTagOpen');
+          expectPath(cst, '1.name').to.equal('if');
+          expectPath(cst, '1.whitespaceStart').to.equal(null);
+          expectPath(cst, '1.whitespaceEnd').to.equal('-');
+          expectPath(cst, '2.type').to.equal('LiquidTagClose');
+          expectPath(cst, '2.name').to.equal('if');
+          expectPath(cst, '2.whitespaceStart').to.equal('-');
+          expectPath(cst, '2.whitespaceEnd').to.equal(null);
+        });
+
+        it('should support nested comments', () => {
+          const testStr =
+            '{% comment -%} ho {% comment %} ho {% endcomment %} ho {%- endcomment %}';
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('comment');
+          expectPath(cst, '0.body').to.equal(' ho {% comment %} ho {% endcomment %} ho ');
+          expectPath(cst, '0.whitespaceStart').to.equal('');
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
+          expectPath(cst, '0.delimiterWhitespaceEnd').to.equal('');
+          expectPath(cst, '0.blockStartLocStart').to.equal(0);
+          expectPath(cst, '0.blockStartLocEnd').to.equal(0 + '{% comment -%}'.length);
+          expectPath(cst, '0.blockEndLocStart').to.equal(
+            testStr.length - '{%- endcomment %}'.length,
+          );
+          expectPath(cst, '0.blockEndLocEnd').to.equal(testStr.length);
+        });
+
+        it('should parse tag open / close', () => {
+          BLOCKS.forEach((block: string) => {
+            cst = toCST(`{% ${block} args -%}{%- end${block} %}`);
+            expectPath(cst, '0.type').to.equal('LiquidTagOpen', block);
+            expectPath(cst, '0.name').to.equal(block);
+            expectPath(cst, '0.whitespaceStart').to.equal(null);
+            expectPath(cst, '0.whitespaceEnd').to.equal('-');
+            if (!NamedTags.hasOwnProperty(block)) {
+              expectPath(cst, '0.markup').to.equal('args');
+            }
+            expectPath(cst, '1.type').to.equal('LiquidTagClose');
+            expectPath(cst, '1.name').to.equal(block);
+            expectPath(cst, '1.whitespaceStart').to.equal('-');
+            expectPath(cst, '1.whitespaceEnd').to.equal(null);
           });
         });
       });
     });
   });
 
-  describe('Case: LiquidNode', () => {
-    it('should parse raw tags', () => {
-      ['style', 'raw'].forEach((raw) => {
-        cst = toLiquidHtmlCST(`{% ${raw} -%}<div>{%- end${raw} %}`);
-        expectPath(cst, '0.type').to.equal('LiquidRawTag');
-        expectPath(cst, '0.body').to.equal('<div>');
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-        expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
-        expectPath(cst, '0.delimiterWhitespaceEnd').to.equal(null);
+  describe('Unit: toLiquidHtmlCST(text)', () => {
+    let cst: LiquidHtmlCST;
+
+    describe('Case: HtmlDoctype', () => {
+      it('should basically parse html doctypes', () => {
+        [
+          { text: '<!doctype html>', legacyDoctypeString: null },
+          { text: '<!doctype html >', legacyDoctypeString: null },
+          {
+            text: `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+             "http://www.w3.org/TR/html4/frameset.dtd">`,
+            legacyDoctypeString: `PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+             "http://www.w3.org/TR/html4/frameset.dtd"`,
+          },
+        ].forEach(({ text, legacyDoctypeString }) => {
+          cst = toLiquidHtmlCST(text);
+          expectPath(cst, '0.type').to.equal('HtmlDoctype');
+          expectPath(cst, '0.legacyDoctypeString').to.equal(legacyDoctypeString);
+        });
       });
     });
 
-    it('should properly return block{Start,End}Loc{Start,End} locations of raw tags', () => {
-      const source = '{% raw -%}<div>{%- endraw %}';
-      cst = toLiquidHtmlCST(source);
-      expectPath(cst, '0.type').to.equal('LiquidRawTag');
-      expectPath(cst, '0.body').to.equal('<div>');
-      expectPath(cst, '0.blockStartLocStart').to.equal(0);
-      expectPath(cst, '0.blockStartLocEnd').to.equal(source.indexOf('<'));
-      expectPath(cst, '0.blockEndLocStart').to.equal(source.indexOf('>') + 1);
-      expectPath(cst, '0.blockEndLocEnd').to.equal(source.length);
-      expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
-      expectPath(cst, '0.delimiterWhitespaceEnd').to.equal(null);
-    });
-
-    it('should basically parse liquid tags', () => {
-      cst = toLiquidHtmlCST('{%   unknown x = 1 %}{% if hi -%}{%- endif %}');
-      expectPath(cst, '0.type').to.equal('LiquidTag');
-      expectPath(cst, '0.name').to.equal('unknown');
-      expectPath(cst, '0.markup').to.equal('x = 1');
-      expectPath(cst, '0.whitespaceStart').to.equal(null);
-      expectPath(cst, '0.whitespaceEnd').to.equal(null);
-      expectPath(cst, '1.type').to.equal('LiquidTagOpen');
-      expectPath(cst, '1.name').to.equal('if');
-      expectPath(cst, '1.whitespaceStart').to.equal(null);
-      expectPath(cst, '1.whitespaceEnd').to.equal('-');
-      expectPath(cst, '2.type').to.equal('LiquidTagClose');
-      expectPath(cst, '2.name').to.equal('if');
-      expectPath(cst, '2.whitespaceStart').to.equal('-');
-      expectPath(cst, '2.whitespaceEnd').to.equal(null);
-    });
-
-    it('should support nested comments', () => {
-      const testStr = '{% comment -%} ho {% comment %} ho {% endcomment %} ho {%- endcomment %}';
-      cst = toLiquidHtmlCST(testStr);
-      expectPath(cst, '0.type').to.equal('LiquidRawTag');
-      expectPath(cst, '0.name').to.equal('comment');
-      expectPath(cst, '0.body').to.equal(' ho {% comment %} ho {% endcomment %} ho ');
-      expectPath(cst, '0.whitespaceStart').to.equal('');
-      expectPath(cst, '0.whitespaceEnd').to.equal('-');
-      expectPath(cst, '0.delimiterWhitespaceStart').to.equal('-');
-      expectPath(cst, '0.delimiterWhitespaceEnd').to.equal('');
-      expectPath(cst, '0.blockStartLocStart').to.equal(0);
-      expectPath(cst, '0.blockStartLocEnd').to.equal(0 + '{% comment -%}'.length);
-      expectPath(cst, '0.blockEndLocStart').to.equal(testStr.length - '{%- endcomment %}'.length);
-      expectPath(cst, '0.blockEndLocEnd').to.equal(testStr.length);
-    });
-
-    it('should parse tag open / close', () => {
-      BLOCKS.forEach((block: string) => {
-        cst = toLiquidHtmlCST(`{% ${block} args -%}{%- end${block} %}`);
-        expectPath(cst, '0.type').to.equal('LiquidTagOpen', block);
-        expectPath(cst, '0.name').to.equal(block);
-        expectPath(cst, '0.whitespaceStart').to.equal(null);
-        expectPath(cst, '0.whitespaceEnd').to.equal('-');
-        if (!NamedTags.hasOwnProperty(block)) {
-          expectPath(cst, '0.markup').to.equal('args');
-        }
-        expectPath(cst, '1.type').to.equal('LiquidTagClose');
-        expectPath(cst, '1.name').to.equal(block);
-        expectPath(cst, '1.whitespaceStart').to.equal('-');
-        expectPath(cst, '1.whitespaceEnd').to.equal(null);
-      });
-    });
-  });
-
-  describe('Case: TextNode', () => {
-    it('should parse text nodes', () => {
-      ['<div>hello</div>', '{% if condition %}hello{% endif %}'].forEach((text) => {
-        cst = toLiquidHtmlCST(text);
-        expectPath(cst, '1.type').to.equal('TextNode');
-        expectPath(cst, '1.value').to.equal('hello');
+    describe('Case: HtmlComment', () => {
+      it('should basically parse html comments', () => {
+        ['<!-- hello world -->'].forEach((text) => {
+          cst = toLiquidHtmlCST(text);
+          expectPath(cst, '0.type').to.equal('HtmlComment');
+          expectPath(cst, '0.body').to.equal('hello world');
+        });
       });
     });
 
-    it('should trim whitespace left and right', () => {
+    describe('Case: HtmlNode', () => {
+      it('should basically parse open and close tags', () => {
+        ['<div></div>', '<div ></div >'].forEach((text) => {
+          cst = toLiquidHtmlCST(text);
+          expectPath(cst, '0.type').to.eql('HtmlTagOpen');
+          expectPath(cst, '0.name.0.value').to.eql('div');
+          expectPath(cst, '1.type').to.eql('HtmlTagClose');
+          expectPath(cst, '1.name.0.value').to.eql('div');
+        });
+      });
+
+      it('should parse compound tag names', () => {
+        cst = toLiquidHtmlCST('<{{header_type}}--header></{{header_type}}--header>');
+        expectPath(cst, '0.type').to.eql('HtmlTagOpen');
+        expectPath(cst, '0.name.0.type').to.eql('LiquidDrop');
+        expectPath(cst, '0.name.0.markup.type').to.eql('LiquidVariable');
+        expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
+        expectPath(cst, '0.name.1.value').to.eql('--header');
+        expectPath(cst, '1.type').to.eql('HtmlTagClose');
+        expectPath(cst, '1.name.0.type').to.eql('LiquidDrop');
+        expectPath(cst, '1.name.0.markup.type').to.eql('LiquidVariable');
+        expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
+        expectPath(cst, '1.name.1.value').to.eql('--header');
+
+        cst = toLiquidHtmlCST('<header--{{header_type}} ></header--{{header_type}} >');
+        expectPath(cst, '0.type').to.eql('HtmlTagOpen');
+        expectPath(cst, '0.name.0.type').to.eql('TextNode');
+        expectPath(cst, '0.name.0.value').to.eql('header--');
+        expectPath(cst, '0.name.1.type').to.eql('LiquidDrop');
+        expectPath(cst, '0.name.1.markup.type').to.eql('LiquidVariable');
+        expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
+        expectPath(cst, '1.type').to.eql('HtmlTagClose');
+        expectPath(cst, '1.name.0.type').to.eql('TextNode');
+        expectPath(cst, '1.name.0.value').to.eql('header--');
+        expectPath(cst, '1.name.1.type').to.eql('LiquidDrop');
+        expectPath(cst, '1.name.1.markup.type').to.eql('LiquidVariable');
+        expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
+      });
+
+      it('should parse liquid drop tag names', () => {
+        cst = toLiquidHtmlCST('<{{ node_type }}></{{ node_type }}>');
+        expectPath(cst, '0.type').to.equal('HtmlTagOpen');
+        expectPath(cst, '0.name.0.type').to.equal('LiquidDrop');
+        expectPath(cst, '0.name.0.markup.type').to.equal('LiquidVariable');
+        expectPath(cst, '0.name.0.markup.expression.type').to.equal('VariableLookup');
+        expectPath(cst, '0.name.0.markup.expression.name').to.equal('node_type');
+        expectPath(cst, '1.type').to.equal('HtmlTagClose');
+        expectPath(cst, '1.name.0.type').to.equal('LiquidDrop');
+        expectPath(cst, '1.name.0.markup.type').to.equal('LiquidVariable');
+        expectPath(cst, '1.name.0.markup.expression.type').to.equal('VariableLookup');
+        expectPath(cst, '1.name.0.markup.expression.name').to.equal('node_type');
+      });
+
+      it('should parse script and style tags as a dump', () => {
+        cst = toLiquidHtmlCST(
+          '<script>\nconst a = {{ product | json }}\n</script><style>\n#id {}\n</style>',
+        );
+        expectPath(cst, '0.type').to.eql('HtmlRawTag');
+        expectPath(cst, '0.name').to.eql('script');
+        expectPath(cst, '0.body').to.eql('\nconst a = {{ product | json }}\n');
+        expectPath(cst, '1.type').to.eql('HtmlRawTag');
+        expectPath(cst, '1.name').to.eql('style');
+        expectPath(cst, '1.body').to.eql('\n#id {}\n');
+      });
+
+      it('should parse nested svg tags as a dump', () => {
+        const parts = ['<svg disabled a=1>', '<svg><path d=1></svg>', '</svg>'];
+        cst = toLiquidHtmlCST(parts.join(''));
+        expectPath(cst, '0.type').to.eql('HtmlRawTag');
+        expectPath(cst, '0.name').to.eql('svg');
+        expectPath(cst, '0.body').to.eql('<svg><path d=1></svg>');
+        expectPath(cst, '0.attrList.0.name.0.type').to.eql('TextNode');
+        expectPath(cst, '0.attrList.0.name.0.value').to.eql('disabled');
+        expectPath(cst, '0.locStart').to.eql(0);
+        expectPath(cst, '0.locEnd').to.eql(parts[0].length + parts[1].length + parts[2].length);
+        expectPath(cst, '0.blockStartLocStart').to.eql(0);
+        expectPath(cst, '0.blockStartLocEnd').to.eql(parts[0].length);
+        expectPath(cst, '0.blockEndLocStart').to.eql(parts[0].length + parts[1].length);
+        expectPath(cst, '0.blockEndLocEnd').to.eql(
+          parts[0].length + parts[1].length + parts[2].length,
+        );
+      });
+
+      it('should properly return block{Start,End}Loc{Start,End} locations of raw tags', () => {
+        const source = '<script>const a = {{ product | json }}</script>';
+        cst = toLiquidHtmlCST(source);
+        expectPath(cst, '0.type').to.equal('HtmlRawTag');
+        expectPath(cst, '0.blockStartLocStart').to.equal(0);
+        expectPath(cst, '0.blockStartLocEnd').to.equal(source.indexOf('const'));
+        expectPath(cst, '0.blockEndLocStart').to.equal(source.indexOf('</script>'));
+        expectPath(cst, '0.blockEndLocEnd').to.equal(source.length);
+      });
+
+      it('should parse void elements', () => {
+        VOID_ELEMENTS.forEach((voidElementName: any) => {
+          cst = toLiquidHtmlCST(`<${voidElementName} disabled>`);
+          expectPath(cst, '0.type').to.equal('HtmlVoidElement');
+          expectPath(cst, '0.name').to.equal(voidElementName);
+          expectPath(cst, '0.attrList.0.name.0.type').to.eql('TextNode');
+          expectPath(cst, '0.attrList.0.name.0.value').to.eql('disabled');
+        });
+      });
+
+      it('should parse empty attributes', () => {
+        ['<div empty>', '<div empty >', '<div\nempty\n>'].forEach((text) => {
+          cst = toLiquidHtmlCST(text);
+          expectPath(cst, '0.attrList.0.type').to.equal('AttrEmpty');
+          expectPath(cst, '0.attrList.0.name.0.value').to.eql('empty');
+          expectPath(cst, '0.name.attrList.0.value').to.be.undefined;
+        });
+      });
+
       [
-        {
-          testCase: '<div>  \n hello  world  </div>',
-          expected: 'hello  world',
-        },
-        { testCase: '<div>  \n bb  </div>', expected: 'bb' },
-        { testCase: '<div>  \n b  </div>', expected: 'b' },
-        {
-          testCase: '{% if a %}  \n hello  world  {% endif %}',
-          expected: 'hello  world',
-        },
-        { testCase: '{% if a %}  \n bb  {% endif %}', expected: 'bb' },
-        { testCase: '{% if a %}  \n b  {% endif %}', expected: 'b' },
-      ].forEach(({ testCase, expected }) => {
-        cst = toLiquidHtmlCST(testCase);
-        expectPath(cst, '1.type').to.equal('TextNode');
-        expectPathStringified(cst, '1.value').to.equal(JSON.stringify(expected));
+        { type: 'AttrSingleQuoted', name: 'single', quote: "'" },
+        { type: 'AttrSingleQuoted', name: 'single', quote: '‘' },
+        { type: 'AttrSingleQuoted', name: 'single', quote: '’' },
+        { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
+        { type: 'AttrDoubleQuoted', name: 'double', quote: '“' },
+        { type: 'AttrDoubleQuoted', name: 'double', quote: '”' },
+        { type: 'AttrUnquoted', name: 'unquoted', quote: '' },
+      ].forEach((testConfig) => {
+        it(`should parse ${testConfig.type} attributes`, () => {
+          [
+            `<div ${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote}>`,
+            `<div ${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote} >`,
+            `<div\n${testConfig.name}=${testConfig.quote}${testConfig.name}${testConfig.quote}\n>`,
+          ].forEach((text) => {
+            cst = toLiquidHtmlCST(text);
+            expectPath(cst, '0.attrList.0.type').to.equal(testConfig.type);
+            expectPath(cst, '0.attrList.0.name.0.value').to.eql(testConfig.name);
+            expectPath(cst, '0.attrList.0.value.0.type').to.eql('TextNode');
+            expectPath(cst, '0.attrList.0.value.0.value').to.eql(testConfig.name);
+          });
+        });
+
+        if (testConfig.name != 'unquoted') {
+          it(`should accept liquid nodes inside ${testConfig.type}`, () => {
+            [
+              `<div ${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote}>`,
+              `<div ${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote} >`,
+              `<div\n${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote}\n>`,
+            ].forEach((text) => {
+              cst = toLiquidHtmlCST(text);
+              expectPath(cst, '0.attrList.0.value.1.type').to.eql('LiquidDrop', text);
+            });
+          });
+        }
+
+        it(`should accept top level liquid nodes that contain ${testConfig.type}`, () => {
+          [
+            `<div {% if A %}${testConfig.name}=${testConfig.quote}https://name${testConfig.quote}{% endif %}>`,
+            `<div {% if A %} ${testConfig.name}=${testConfig.quote}https://name${testConfig.quote} {% endif %}>`,
+            `<div\n{% if A %}\n${testConfig.name}=${testConfig.quote}https://name${testConfig.quote}\n{% endif %}>`,
+          ].forEach((text) => {
+            cst = toLiquidHtmlCST(text);
+            expectPath(cst, '0.attrList.0.type').to.eql('LiquidTagOpen', text);
+            expectPath(cst, '0.attrList.1.type').to.eql(testConfig.type, text);
+            expectPath(cst, '0.attrList.1.value.0.value').to.eql('https://name');
+            expectPath(cst, '0.attrList.2.type').to.eql('LiquidTagClose', text);
+          });
+        });
       });
+    });
+
+    describe('Case: TextNode', () => {
+      it('should parse text nodes', () => {
+        ['<div>hello</div>', '{% if condition %}hello{% endif %}'].forEach((text) => {
+          cst = toLiquidHtmlCST(text);
+          expectPath(cst, '1.type').to.equal('TextNode');
+          expectPath(cst, '1.value').to.equal('hello');
+        });
+      });
+
+      it('should trim whitespace left and right', () => {
+        [
+          {
+            testCase: '<div>  \n hello  world  </div>',
+            expected: 'hello  world',
+          },
+          { testCase: '<div>  \n bb  </div>', expected: 'bb' },
+          { testCase: '<div>  \n b  </div>', expected: 'b' },
+          {
+            testCase: '{% if a %}  \n hello  world  {% endif %}',
+            expected: 'hello  world',
+          },
+          { testCase: '{% if a %}  \n bb  {% endif %}', expected: 'bb' },
+          { testCase: '{% if a %}  \n b  {% endif %}', expected: 'b' },
+        ].forEach(({ testCase, expected }) => {
+          cst = toLiquidHtmlCST(testCase);
+          expectPath(cst, '1.type').to.equal('TextNode');
+          expectPathStringified(cst, '1.value').to.equal(JSON.stringify(expected));
+        });
+      });
+    });
+
+    it('should throw when trying to parse unparseable code', () => {
+      const testCases = ['{% 10293 %}', '<h=>', '{% if', '{{ n', '<div>{{ n{% if'];
+      for (const testCase of testCases) {
+        try {
+          toLiquidHtmlCST(testCase);
+          expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+        } catch (e: any) {
+          expect(e.name).to.eql('LiquidHTMLParsingError');
+          expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+        }
+      }
+    });
+
+    it('should parse inline comments', () => {
+      cst = toLiquidHtmlCST('{% # hello world \n # hi %}');
+      expectPath(cst, '0.type').to.eql('LiquidTag');
+      expectPath(cst, '0.name').to.eql('#');
+      expectPath(cst, '0.markup').to.eql('hello world \n # hi');
     });
   });
 
-  it('should throw when trying to parse unparseable code', () => {
-    const testCases = ['{% 10293 %}', '<h=>', '{% if', '{{ n', '<div>{{ n{% if'];
-    for (const testCase of testCases) {
-      try {
-        toLiquidHtmlCST(testCase);
-        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
-      } catch (e) {
-        expect(e.name).to.eql('LiquidHTMLParsingError');
-        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
-      }
-    }
-  });
+  describe('Unit: toLiquidCST(text)', () => {
+    let cst: LiquidHtmlCST;
+    it('should not throw when trying to parse unparseable code', () => {
+      cst = toLiquidCST(`
+        {%- liquid
+          assign var1 = product
+        -%}
+        <table>
+          {% tablerow var2 in collections.first.products %}
+            {% assign var3 = var2 %}
+            {{ var3.title }}
+      `);
 
-  it('should parse inline comments', () => {
-    cst = toLiquidHtmlCST('{% # hello world \n # hi %}');
-    expectPath(cst, '0.type').to.eql('LiquidTag');
-    expectPath(cst, '0.name').to.eql('#');
-    expectPath(cst, '0.markup').to.eql('hello world \n # hi');
+      expectPath(cst, '0.type').to.eql('LiquidTag');
+      expectPath(cst, '0.name').to.eql('liquid');
+      expectPath(cst, '1.type').to.eql('TextNode');
+      expectPath(cst, '1.value').to.eql('<table>');
+      expectPath(cst, '2.type').to.eql('LiquidTagOpen');
+      expectPath(cst, '2.name').to.eql('tablerow');
+      expectPath(cst, '3.type').to.eql('LiquidTag');
+      expectPath(cst, '3.name').to.eql('assign');
+    });
+
+    it('should parse inline comments', () => {
+      cst = toLiquidCST('{% # hello world \n # hi %}');
+      expectPath(cst, '0.type').to.eql('LiquidTag');
+      expectPath(cst, '0.name').to.eql('#');
+      expectPath(cst, '0.markup').to.eql('hello world \n # hi');
+    });
   });
 
   function expectPath(cst: LiquidHtmlCST, path: string) {

--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -1,587 +1,651 @@
 import { expect } from 'chai';
-import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/stage-2-ast';
+import { toLiquidHtmlAST, toLiquidAST, LiquidHtmlNode } from '~/parser/stage-2-ast';
 import { deepGet } from '~/utils';
 
-describe('Unit: toLiquidHtmlAST', () => {
-  let ast;
+describe('Unit: Stage 2 (AST)', () => {
+  describe('Unit: toLiquidHtmlAST(text) and toLiquidAST(text)', () => {
+    [
+      {
+        title: 'toLiquidHtmlAST(text)',
+        fn: toLiquidHtmlAST,
+      },
+      {
+        title: 'toLiquidAST(text)',
+        fn: toLiquidAST,
+      },
+    ].forEach((testContext) => {
+      let ast: any;
 
-  describe('Unit: LiquidDrop', () => {
-    it('should transform a base case Liquid Drop into a LiquidDrop', () => {
-      ast = toLiquidHtmlAST('{{ !-asd }}');
-      expectPath(ast, 'children.0').to.exist;
-      expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-      expectPath(ast, 'children.0.markup').to.eql('!-asd');
-      expectPosition(ast, 'children.0');
-    });
+      const title = testContext.title;
+      const toAST = testContext.fn;
 
-    it('should parse strings as LiquidVariable > String', () => {
-      [
-        { expression: `"string o' string"`, value: `string o' string`, single: false },
-        { expression: `'He said: "hi!"'`, value: `He said: "hi!"`, single: true },
-      ].forEach(({ expression, value, single }) => {
-        ast = toLiquidHtmlAST(`{{ ${expression} }}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.type').to.eql('String');
-        expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
-        expectPath(ast, 'children.0.markup.expression.single').to.eql(single);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-
-    it('should parse numbers as LiquidVariable > Number', () => {
-      [
-        { expression: `1`, value: '1' },
-        { expression: `1.02`, value: '1.02' },
-        { expression: `0`, value: '0' },
-        { expression: `-0`, value: '-0' },
-        { expression: `-0.0`, value: '-0.0' },
-      ].forEach(({ expression, value }) => {
-        ast = toLiquidHtmlAST(`{{ ${expression} }}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.type').to.eql('Number');
-        expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-
-    it('should parse numbers as LiquidVariable > LiquidLiteral', () => {
-      [
-        { expression: `nil`, value: null },
-        { expression: `null`, value: null },
-        { expression: `true`, value: true },
-        { expression: `blank`, value: '' },
-        { expression: `empty`, value: '' },
-      ].forEach(({ expression, value }) => {
-        ast = toLiquidHtmlAST(`{{ ${expression} }}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.type').to.eql('LiquidLiteral');
-        expectPath(ast, 'children.0.markup.expression.keyword').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-
-    it('should parse ranges as LiquidVariable > Range', () => {
-      [
-        {
-          expression: `(0..5)`,
-          start: { value: '0', type: 'Number' },
-          end: { value: '5', type: 'Number' },
-        },
-        {
-          expression: `( 0 .. 5 )`,
-          start: { value: '0', type: 'Number' },
-          end: { value: '5', type: 'Number' },
-        },
-        {
-          expression: `(true..false)`,
-          start: { value: true, type: 'LiquidLiteral' },
-          end: { value: false, type: 'LiquidLiteral' },
-        },
-      ].forEach(({ expression, start, end }) => {
-        ast = toLiquidHtmlAST(`{{ ${expression} }}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.type').to.eql('Range');
-        expectPath(ast, 'children.0.markup.expression.start.type').to.eql(start.type);
-        expectPath(ast, 'children.0.markup.expression.start.value').to.eql(start.value);
-        expectPath(ast, 'children.0.markup.expression.end.type').to.eql(end.type);
-        expectPath(ast, 'children.0.markup.expression.end.value').to.eql(end.value);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-        expectPosition(ast, 'children.0.markup.expression.start');
-        expectPosition(ast, 'children.0.markup.expression.end');
-      });
-    });
-
-    interface Lookup {
-      type: 'VariableLookup';
-      lookups: (string | number | Lookup)[];
-      name: string | undefined;
-    }
-
-    it('should parse variable lookups as LiquidVariable > VariableLookup', () => {
-      const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
-        type: 'VariableLookup',
-        name,
-        lookups,
-      });
-      [
-        { expression: `x`, name: 'x', lookups: [] },
-        { expression: `x.y`, name: 'x', lookups: ['y'] },
-        { expression: `x["y"]`, name: 'x', lookups: ['y'] },
-        { expression: `x['y']`, name: 'x', lookups: ['y'] },
-        { expression: `x[1]`, name: 'x', lookups: [1] },
-        { expression: `x.y.z`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `x["y"]["z"]`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `x["y"].z`, name: 'x', lookups: ['y', 'z'] },
-        { expression: `["product"]`, name: null, lookups: ['product'] },
-        { expression: `page.about-us`, name: 'page', lookups: ['about-us'] },
-        { expression: `["x"].y`, name: null, lookups: ['x', 'y'] },
-        { expression: `["x"]["y"]`, name: null, lookups: ['x', 'y'] },
-        { expression: `x[y]`, name: 'x', lookups: [v('y')] },
-        { expression: `x[y.z]`, name: 'x', lookups: [v('y', ['z'])] },
-      ].forEach(({ expression, name, lookups }) => {
-        ast = toLiquidHtmlAST(`{{ ${expression} }}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
-        expectPath(ast, 'children.0.markup.expression.type').to.eql('VariableLookup');
-        expectPath(ast, 'children.0.markup.expression.name').to.eql(name);
-
-        lookups.forEach((lookup: string | number | Lookup, i: number) => {
-          switch (typeof lookup) {
-            case 'string': {
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal('String');
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.value`).to.equal(lookup);
-              break;
-            }
-            case 'number': {
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal('Number');
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.value`).to.equal(
-                lookup.toString(),
-              );
-              break;
-            }
-            default: {
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal(
-                'VariableLookup',
-              );
-              expectPath(ast, `children.0.markup.expression.lookups.${i}.name`).to.equal(
-                lookup.name,
-              );
-              lookup.lookups.forEach((val, j) => {
-                // Being lazy here... Assuming string properties.
-                expectPath(
-                  ast,
-                  `children.0.markup.expression.lookups.${i}.lookups.${j}.type`,
-                ).to.equal('String');
-                expectPath(
-                  ast,
-                  `children.0.markup.expression.lookups.${i}.lookups.${j}.value`,
-                ).to.equal(val);
-              });
-              break;
-            }
-          }
-        });
-
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-
-    it('should parse filters', () => {
-      interface Filter {
-        name: string;
-        args: FilterArgument[];
-      }
-      type FilterArgument = any;
-
-      const filter = (name: string, args: FilterArgument[] = []): Filter => ({ name, args });
-      const arg = (type: string, value: string) => ({ type, value });
-      const namedArg = (name: string, valueType: string) => ({
-        type: 'NamedArgument',
-        name,
-        valueType,
-      });
-      [
-        { expression: `| filter1`, filters: [filter('filter1')] },
-        { expression: `| filter1 | filter2`, filters: [filter('filter1'), filter('filter2')] },
-        {
-          expression: `| filter1: 'hi', 'there'`,
-          filters: [filter('filter1', [arg('String', 'hi'), arg('String', 'there')])],
-        },
-        {
-          expression: `| filter1: key: value, kind: 'string'`,
-          filters: [
-            filter('filter1', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
-          ],
-        },
-        {
-          expression: `| f1: 'hi', key: (0..1) | f2: key: value, kind: 'string'`,
-          filters: [
-            filter('f1', [arg('String', 'hi'), namedArg('key', 'Range')]),
-            filter('f2', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
-          ],
-        },
-      ].forEach(({ expression, filters }) => {
-        ast = toLiquidHtmlAST(`{{ 'hello' ${expression} }}`);
-        expectPath(ast, 'children.0.type').to.equal('LiquidDrop');
-        expectPath(ast, 'children.0.markup.type').to.equal('LiquidVariable');
-        expectPath(ast, 'children.0.markup.rawSource').to.equal(`'hello' ` + expression);
-        expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(filters.length);
-        filters.forEach((filter, i) => {
-          expectPath(ast, `children.0.markup.filters.${i}`).to.exist;
-          expectPath(ast, `children.0.markup.filters.${i}.type`).to.equal(
-            'LiquidFilter',
-            expression,
-          );
-          expectPath(ast, `children.0.markup.filters.${i}.name`).to.equal(filter.name);
-          expectPath(ast, `children.0.markup.filters.${i}.args`).to.exist;
-          expectPath(ast, `children.0.markup.filters.${i}.args`).to.have.lengthOf(
-            filter.args.length,
-          );
-          filter.args.forEach((arg: any, j) => {
-            expectPath(ast, `children.0.markup.filters.${i}.args`).to.exist;
-            switch (arg.type) {
-              case 'String': {
-                expectPath(ast, `children.0.markup.filters.${i}.args.${j}.type`).to.equal('String');
-                expectPath(ast, `children.0.markup.filters.${i}.args.${j}.value`).to.equal(
-                  arg.value,
-                );
-                break;
-              }
-              case 'NamedArgument': {
-                expectPath(ast, `children.0.markup.filters.${i}.args`).to.not.be.empty;
-                expectPath(ast, `children.0.markup.filters.${i}.args.${j}.type`).to.equal(
-                  'NamedArgument',
-                );
-                expectPath(ast, `children.0.markup.filters.${i}.args.${j}.name`).to.equal(arg.name);
-                expectPath(ast, `children.0.markup.filters.${i}.args.${j}.value.type`).to.equal(
-                  arg.valueType,
-                );
-                break;
-              }
-            }
-          });
-        });
-        expectPath(ast, 'children.0.whitespaceStart').to.equal('');
-        expectPath(ast, 'children.0.whitespaceEnd').to.equal('');
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-  });
-
-  describe('Case: LiquidTag', () => {
-    it('should transform a basic Liquid Tag into a LiquidTag', () => {
-      ast = toLiquidHtmlAST('{% name %}{% if -%}{%- endif %}');
-      expectPath(ast, 'children.0').to.exist;
-      expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-      expectPath(ast, 'children.0.name').to.eql('name');
-      expectPath(ast, 'children.0.markup').to.eql('');
-      expectPath(ast, 'children.0.children').to.be.undefined;
-      expectPath(ast, 'children.1.whitespaceStart').to.eql('');
-      expectPath(ast, 'children.1.whitespaceEnd').to.eql('-');
-      expectPath(ast, 'children.1.delimiterWhitespaceStart').to.eql('-');
-      expectPath(ast, 'children.1.delimiterWhitespaceEnd').to.eql('');
-      expectPosition(ast, 'children.0');
-    });
-
-    it('should parse echo tags', () => {
-      [
-        { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
-        { expression: `x | f`, expressionType: 'VariableLookup', filters: ['f'] },
-      ].forEach(({ expression, expressionType, expressionValue, filters }) => {
-        ast = toLiquidHtmlAST(`{% echo ${expression} -%}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-        expectPath(ast, 'children.0.name').to.eql('echo');
-        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
-        expectPath(ast, 'children.0.markup.expression.type').to.eql(expressionType);
-        if (expressionValue)
-          expectPath(ast, 'children.0.markup.expression.value').to.eql(expressionValue);
-        expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(filters.length);
-        expectPath(ast, 'children.0.children').to.be.undefined;
-        expectPath(ast, 'children.0.whitespaceStart').to.eql('');
-        expectPath(ast, 'children.0.whitespaceEnd').to.eql('-');
-        expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
-        expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.expression');
-      });
-    });
-
-    it('should parse assign tags', () => {
-      [
-        {
-          expression: `x = "hi"`,
-          name: 'x',
-          expressionType: 'String',
-          expressionValue: 'hi',
-          filters: [],
-        },
-        { expression: `z = y | f`, name: 'z', expressionType: 'VariableLookup', filters: ['f'] },
-      ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
-        ast = toLiquidHtmlAST(`{% assign ${expression} -%}`);
-        expectPath(ast, 'children.0').to.exist;
-        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-        expectPath(ast, 'children.0.name').to.eql('assign');
-        expectPath(ast, 'children.0.markup.type').to.eql('AssignMarkup');
-        expectPath(ast, 'children.0.markup.name').to.eql(name);
-        expectPath(ast, 'children.0.markup.value.expression.type').to.eql(expressionType);
-        if (expressionValue)
-          expectPath(ast, 'children.0.markup.value.expression.value').to.eql(expressionValue);
-        expectPath(ast, 'children.0.markup.value.filters').to.have.lengthOf(filters.length);
-        expectPath(ast, 'children.0.children').to.be.undefined;
-        expectPath(ast, 'children.0.whitespaceStart').to.eql('');
-        expectPath(ast, 'children.0.whitespaceEnd').to.eql('-');
-        expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
-        expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-        expectPosition(ast, 'children.0.markup.value');
-        expectPosition(ast, 'children.0.markup.value.expression');
-      });
-    });
-
-    it('should parse render tags', () => {
-      [
-        {
-          expression: `"snippet"`,
-          snippetType: 'String',
-          alias: null,
-          renderVariableExpression: null,
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" as foo`,
-          snippetType: 'String',
-          alias: 'foo',
-          renderVariableExpression: null,
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" with "string" as foo`,
-          snippetType: 'String',
-          alias: 'foo',
-          renderVariableExpression: {
-            kind: 'with',
-            name: {
-              type: 'String',
-            },
-          },
-          namedArguments: [],
-        },
-        {
-          expression: `"snippet" for products as product`,
-          snippetType: 'String',
-          alias: 'product',
-          renderVariableExpression: {
-            kind: 'for',
-            name: {
-              type: 'VariableLookup',
-            },
-          },
-          namedArguments: [],
-        },
-        {
-          expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
-          snippetType: 'VariableLookup',
-          alias: 'foo',
-          renderVariableExpression: {
-            kind: 'with',
-            name: {
-              type: 'String',
-            },
-          },
-          namedArguments: [
-            { name: 'key1', valueType: 'VariableLookup' },
-            { name: 'key2', valueType: 'String' },
-          ],
-        },
-      ].forEach(({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
-        ast = toLiquidHtmlAST(`{% render ${expression} -%}`);
-        expectPath(ast, 'children.0.type').to.equal('LiquidTag');
-        expectPath(ast, 'children.0.name').to.equal('render');
-        expectPath(ast, 'children.0.markup.type').to.equal('RenderMarkup');
-        expectPath(ast, 'children.0.markup.snippet.type').to.equal(snippetType);
-        if (renderVariableExpression) {
-          expectPath(ast, 'children.0.markup.variable.type').to.equal('RenderVariableExpression');
-          expectPath(ast, 'children.0.markup.variable.kind').to.equal(
-            renderVariableExpression.kind,
-          );
-          expectPath(ast, 'children.0.markup.variable.name.type').to.equal(
-            renderVariableExpression.name.type,
-          );
-          expectPosition(ast, 'children.0.markup.variable');
-          expectPosition(ast, 'children.0.markup.variable.name');
-        } else {
-          expectPath(ast, 'children.0.markup.variable').to.equal(null);
-        }
-        expectPath(ast, 'children.0.markup.alias').to.equal(alias);
-        expectPath(ast, 'children.0.markup.args').to.have.lengthOf(namedArguments.length);
-        namedArguments.forEach(({ name, valueType }, i) => {
-          expectPath(ast, `children.0.markup.args.${i}.type`).to.equal('NamedArgument');
-          expectPath(ast, `children.0.markup.args.${i}.name`).to.equal(name);
-          expectPath(ast, `children.0.markup.args.${i}.value.type`).to.equal(valueType);
-          expectPosition(ast, `children.0.markup.args.${i}`);
-          expectPosition(ast, `children.0.markup.args.${i}.value`);
-        });
-        expectPath(ast, 'children.0.whitespaceStart').to.equal('');
-        expectPath(ast, 'children.0.whitespaceEnd').to.equal('-');
-        expectPosition(ast, 'children.0');
-        expectPosition(ast, 'children.0.markup');
-      });
-    });
-
-    it('should parse conditional tags into conditional expressions', () => {
-      ['if', 'unless'].forEach((tagName) => {
-        [
-          {
-            expression: 'a',
-            markup: {
-              type: 'VariableLookup',
-            },
-          },
-          {
-            expression: 'a and "string"',
-            markup: {
-              type: 'LogicalExpression',
-              relation: 'and',
-              left: { type: 'VariableLookup' },
-              right: { type: 'String' },
-            },
-          },
-          {
-            expression: 'a and "string" or a<1',
-            markup: {
-              type: 'LogicalExpression',
-              relation: 'and',
-              left: { type: 'VariableLookup' },
-              right: {
-                type: 'LogicalExpression',
-                relation: 'or',
-                left: { type: 'String' },
-                right: {
-                  type: 'Comparison',
-                  comparator: '<',
-                  left: { type: 'VariableLookup' },
-                  right: { type: 'Number' },
-                },
-              },
-            },
-          },
-        ].forEach(({ expression, markup }) => {
-          ast = toLiquidHtmlAST(`{% ${tagName} ${expression} -%}{% end${tagName} %}`);
-          expectPath(ast, 'children.0.type').to.equal('LiquidTag');
-          expectPath(ast, 'children.0.name').to.equal(tagName);
-          let cursor: any = markup;
-          let prefix = '';
-          while (cursor) {
-            switch (cursor.type) {
-              case 'LogicalExpression': {
-                expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
-                expectPath(ast, `children.0.markup${prefix}.relation`).to.equal(cursor.relation);
-                expectPath(ast, `children.0.markup${prefix}.left.type`).to.equal(cursor.left.type);
-                cursor = cursor.right;
-                prefix = prefix + '.right';
-                break;
-              }
-              case 'Comparison': {
-                expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
-                expectPath(ast, `children.0.markup${prefix}.comparator`).to.equal(
-                  cursor.comparator,
-                );
-                expectPath(ast, `children.0.markup${prefix}.left.type`).to.equal(cursor.left.type);
-                expectPath(ast, `children.0.markup${prefix}.right.type`).to.equal(
-                  cursor.right.type,
-                );
-                cursor = cursor.right;
-                prefix = prefix + '.right';
-                break;
-              }
-              default: {
-                expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
-                cursor = null;
-                break;
-              }
-            }
-          }
-
+      describe(`${title} - Unit: LiquidDrop`, () => {
+        it('should transform a base case Liquid Drop into a LiquidDrop', () => {
+          ast = toAST('{{ !-asd }}');
+          expectPath(ast, 'children.0').to.exist;
+          expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+          expectPath(ast, 'children.0.markup').to.eql('!-asd');
           expectPosition(ast, 'children.0');
         });
+
+        it('should parse strings as LiquidVariable > String', () => {
+          [
+            { expression: `"string o' string"`, value: `string o' string`, single: false },
+            { expression: `'He said: "hi!"'`, value: `He said: "hi!"`, single: true },
+          ].forEach(({ expression, value, single }) => {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('String');
+            expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
+            expectPath(ast, 'children.0.markup.expression.single').to.eql(single);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+
+        it('should parse numbers as LiquidVariable > Number', () => {
+          [
+            { expression: `1`, value: '1' },
+            { expression: `1.02`, value: '1.02' },
+            { expression: `0`, value: '0' },
+            { expression: `-0`, value: '-0' },
+            { expression: `-0.0`, value: '-0.0' },
+          ].forEach(({ expression, value }) => {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('Number');
+            expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+
+        it('should parse numbers as LiquidVariable > LiquidLiteral', () => {
+          [
+            { expression: `nil`, value: null },
+            { expression: `null`, value: null },
+            { expression: `true`, value: true },
+            { expression: `blank`, value: '' },
+            { expression: `empty`, value: '' },
+          ].forEach(({ expression, value }) => {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('LiquidLiteral');
+            expectPath(ast, 'children.0.markup.expression.keyword').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.value').to.eql(value);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+
+        it('should parse ranges as LiquidVariable > Range', () => {
+          [
+            {
+              expression: `(0..5)`,
+              start: { value: '0', type: 'Number' },
+              end: { value: '5', type: 'Number' },
+            },
+            {
+              expression: `( 0 .. 5 )`,
+              start: { value: '0', type: 'Number' },
+              end: { value: '5', type: 'Number' },
+            },
+            {
+              expression: `(true..false)`,
+              start: { value: true, type: 'LiquidLiteral' },
+              end: { value: false, type: 'LiquidLiteral' },
+            },
+          ].forEach(({ expression, start, end }) => {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('Range');
+            expectPath(ast, 'children.0.markup.expression.start.type').to.eql(start.type);
+            expectPath(ast, 'children.0.markup.expression.start.value').to.eql(start.value);
+            expectPath(ast, 'children.0.markup.expression.end.type').to.eql(end.type);
+            expectPath(ast, 'children.0.markup.expression.end.value').to.eql(end.value);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+            expectPosition(ast, 'children.0.markup.expression.start');
+            expectPosition(ast, 'children.0.markup.expression.end');
+          });
+        });
+
+        interface Lookup {
+          type: 'VariableLookup';
+          lookups: (string | number | Lookup)[];
+          name: string | undefined;
+        }
+
+        it('should parse variable lookups as LiquidVariable > VariableLookup', () => {
+          const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
+            type: 'VariableLookup',
+            name,
+            lookups,
+          });
+          [
+            { expression: `x`, name: 'x', lookups: [] },
+            { expression: `x.y`, name: 'x', lookups: ['y'] },
+            { expression: `x["y"]`, name: 'x', lookups: ['y'] },
+            { expression: `x['y']`, name: 'x', lookups: ['y'] },
+            { expression: `x[1]`, name: 'x', lookups: [1] },
+            { expression: `x.y.z`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `x["y"]["z"]`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `x["y"].z`, name: 'x', lookups: ['y', 'z'] },
+            { expression: `["product"]`, name: null, lookups: ['product'] },
+            { expression: `page.about-us`, name: 'page', lookups: ['about-us'] },
+            { expression: `["x"].y`, name: null, lookups: ['x', 'y'] },
+            { expression: `["x"]["y"]`, name: null, lookups: ['x', 'y'] },
+            { expression: `x[y]`, name: 'x', lookups: [v('y')] },
+            { expression: `x[y.z]`, name: 'x', lookups: [v('y', ['z'])] },
+          ].forEach(({ expression, name, lookups }) => {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('VariableLookup');
+            expectPath(ast, 'children.0.markup.expression.name').to.eql(name);
+
+            lookups.forEach((lookup: string | number | Lookup, i: number) => {
+              switch (typeof lookup) {
+                case 'string': {
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal(
+                    'String',
+                  );
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.value`).to.equal(
+                    lookup,
+                  );
+                  break;
+                }
+                case 'number': {
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal(
+                    'Number',
+                  );
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.value`).to.equal(
+                    lookup.toString(),
+                  );
+                  break;
+                }
+                default: {
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.type`).to.equal(
+                    'VariableLookup',
+                  );
+                  expectPath(ast, `children.0.markup.expression.lookups.${i}.name`).to.equal(
+                    lookup.name,
+                  );
+                  lookup.lookups.forEach((val, j) => {
+                    // Being lazy here... Assuming string properties.
+                    expectPath(
+                      ast,
+                      `children.0.markup.expression.lookups.${i}.lookups.${j}.type`,
+                    ).to.equal('String');
+                    expectPath(
+                      ast,
+                      `children.0.markup.expression.lookups.${i}.lookups.${j}.value`,
+                    ).to.equal(val);
+                  });
+                  break;
+                }
+              }
+            });
+
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+
+        it('should parse filters', () => {
+          interface Filter {
+            name: string;
+            args: FilterArgument[];
+          }
+          type FilterArgument = any;
+
+          const filter = (name: string, args: FilterArgument[] = []): Filter => ({ name, args });
+          const arg = (type: string, value: string) => ({ type, value });
+          const namedArg = (name: string, valueType: string) => ({
+            type: 'NamedArgument',
+            name,
+            valueType,
+          });
+          [
+            { expression: `| filter1`, filters: [filter('filter1')] },
+            { expression: `| filter1 | filter2`, filters: [filter('filter1'), filter('filter2')] },
+            {
+              expression: `| filter1: 'hi', 'there'`,
+              filters: [filter('filter1', [arg('String', 'hi'), arg('String', 'there')])],
+            },
+            {
+              expression: `| filter1: key: value, kind: 'string'`,
+              filters: [
+                filter('filter1', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
+              ],
+            },
+            {
+              expression: `| f1: 'hi', key: (0..1) | f2: key: value, kind: 'string'`,
+              filters: [
+                filter('f1', [arg('String', 'hi'), namedArg('key', 'Range')]),
+                filter('f2', [namedArg('key', 'VariableLookup'), namedArg('kind', 'String')]),
+              ],
+            },
+          ].forEach(({ expression, filters }) => {
+            ast = toAST(`{{ 'hello' ${expression} }}`);
+            expectPath(ast, 'children.0.type').to.equal('LiquidDrop');
+            expectPath(ast, 'children.0.markup.type').to.equal('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.equal(`'hello' ` + expression);
+            expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(filters.length);
+            filters.forEach((filter, i) => {
+              expectPath(ast, `children.0.markup.filters.${i}`).to.exist;
+              expectPath(ast, `children.0.markup.filters.${i}.type`).to.equal(
+                'LiquidFilter',
+                expression,
+              );
+              expectPath(ast, `children.0.markup.filters.${i}.name`).to.equal(filter.name);
+              expectPath(ast, `children.0.markup.filters.${i}.args`).to.exist;
+              expectPath(ast, `children.0.markup.filters.${i}.args`).to.have.lengthOf(
+                filter.args.length,
+              );
+              filter.args.forEach((arg: any, j) => {
+                expectPath(ast, `children.0.markup.filters.${i}.args`).to.exist;
+                switch (arg.type) {
+                  case 'String': {
+                    expectPath(ast, `children.0.markup.filters.${i}.args.${j}.type`).to.equal(
+                      'String',
+                    );
+                    expectPath(ast, `children.0.markup.filters.${i}.args.${j}.value`).to.equal(
+                      arg.value,
+                    );
+                    break;
+                  }
+                  case 'NamedArgument': {
+                    expectPath(ast, `children.0.markup.filters.${i}.args`).to.not.be.empty;
+                    expectPath(ast, `children.0.markup.filters.${i}.args.${j}.type`).to.equal(
+                      'NamedArgument',
+                    );
+                    expectPath(ast, `children.0.markup.filters.${i}.args.${j}.name`).to.equal(
+                      arg.name,
+                    );
+                    expectPath(ast, `children.0.markup.filters.${i}.args.${j}.value.type`).to.equal(
+                      arg.valueType,
+                    );
+                    break;
+                  }
+                }
+              });
+            });
+            expectPath(ast, 'children.0.whitespaceStart').to.equal('');
+            expectPath(ast, 'children.0.whitespaceEnd').to.equal('');
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+      });
+
+      describe(`${title} - Case: LiquidTag`, () => {
+        it('should transform a basic Liquid Tag into a LiquidTag', () => {
+          ast = toAST('{% name %}{% if -%}{%- endif %}');
+          expectPath(ast, 'children.0').to.exist;
+          expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+          expectPath(ast, 'children.0.name').to.eql('name');
+          expectPath(ast, 'children.0.markup').to.eql('');
+          expectPath(ast, 'children.0.children').to.be.undefined;
+          expectPath(ast, 'children.1.whitespaceStart').to.eql('');
+          expectPath(ast, 'children.1.whitespaceEnd').to.eql('-');
+          expectPath(ast, 'children.1.delimiterWhitespaceStart').to.eql('-');
+          expectPath(ast, 'children.1.delimiterWhitespaceEnd').to.eql('');
+          expectPosition(ast, 'children.0');
+        });
+
+        it('should parse echo tags', () => {
+          [
+            { expression: `"hi"`, expressionType: 'String', expressionValue: 'hi', filters: [] },
+            { expression: `x | f`, expressionType: 'VariableLookup', filters: ['f'] },
+          ].forEach(({ expression, expressionType, expressionValue, filters }) => {
+            ast = toAST(`{% echo ${expression} -%}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+            expectPath(ast, 'children.0.name').to.eql('echo');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.expression.type').to.eql(expressionType);
+            if (expressionValue)
+              expectPath(ast, 'children.0.markup.expression.value').to.eql(expressionValue);
+            expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(filters.length);
+            expectPath(ast, 'children.0.children').to.be.undefined;
+            expectPath(ast, 'children.0.whitespaceStart').to.eql('');
+            expectPath(ast, 'children.0.whitespaceEnd').to.eql('-');
+            expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
+            expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          });
+        });
+
+        it('should parse assign tags', () => {
+          [
+            {
+              expression: `x = "hi"`,
+              name: 'x',
+              expressionType: 'String',
+              expressionValue: 'hi',
+              filters: [],
+            },
+            {
+              expression: `z = y | f`,
+              name: 'z',
+              expressionType: 'VariableLookup',
+              filters: ['f'],
+            },
+          ].forEach(({ expression, name, expressionType, expressionValue, filters }) => {
+            ast = toAST(`{% assign ${expression} -%}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+            expectPath(ast, 'children.0.name').to.eql('assign');
+            expectPath(ast, 'children.0.markup.type').to.eql('AssignMarkup');
+            expectPath(ast, 'children.0.markup.name').to.eql(name);
+            expectPath(ast, 'children.0.markup.value.expression.type').to.eql(expressionType);
+            if (expressionValue)
+              expectPath(ast, 'children.0.markup.value.expression.value').to.eql(expressionValue);
+            expectPath(ast, 'children.0.markup.value.filters').to.have.lengthOf(filters.length);
+            expectPath(ast, 'children.0.children').to.be.undefined;
+            expectPath(ast, 'children.0.whitespaceStart').to.eql('');
+            expectPath(ast, 'children.0.whitespaceEnd').to.eql('-');
+            expectPath(ast, 'children.0.delimiterWhitespaceStart').to.eql(undefined);
+            expectPath(ast, 'children.0.delimiterWhitespaceEnd').to.eql(undefined);
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.value');
+            expectPosition(ast, 'children.0.markup.value.expression');
+          });
+        });
+
+        it('should parse render tags', () => {
+          [
+            {
+              expression: `"snippet"`,
+              snippetType: 'String',
+              alias: null,
+              renderVariableExpression: null,
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" as foo`,
+              snippetType: 'String',
+              alias: 'foo',
+              renderVariableExpression: null,
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" with "string" as foo`,
+              snippetType: 'String',
+              alias: 'foo',
+              renderVariableExpression: {
+                kind: 'with',
+                name: {
+                  type: 'String',
+                },
+              },
+              namedArguments: [],
+            },
+            {
+              expression: `"snippet" for products as product`,
+              snippetType: 'String',
+              alias: 'product',
+              renderVariableExpression: {
+                kind: 'for',
+                name: {
+                  type: 'VariableLookup',
+                },
+              },
+              namedArguments: [],
+            },
+            {
+              expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
+              snippetType: 'VariableLookup',
+              alias: 'foo',
+              renderVariableExpression: {
+                kind: 'with',
+                name: {
+                  type: 'String',
+                },
+              },
+              namedArguments: [
+                { name: 'key1', valueType: 'VariableLookup' },
+                { name: 'key2', valueType: 'String' },
+              ],
+            },
+          ].forEach(
+            ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
+              ast = toAST(`{% render ${expression} -%}`);
+              expectPath(ast, 'children.0.type').to.equal('LiquidTag');
+              expectPath(ast, 'children.0.name').to.equal('render');
+              expectPath(ast, 'children.0.markup.type').to.equal('RenderMarkup');
+              expectPath(ast, 'children.0.markup.snippet.type').to.equal(snippetType);
+              if (renderVariableExpression) {
+                expectPath(ast, 'children.0.markup.variable.type').to.equal(
+                  'RenderVariableExpression',
+                );
+                expectPath(ast, 'children.0.markup.variable.kind').to.equal(
+                  renderVariableExpression.kind,
+                );
+                expectPath(ast, 'children.0.markup.variable.name.type').to.equal(
+                  renderVariableExpression.name.type,
+                );
+                expectPosition(ast, 'children.0.markup.variable');
+                expectPosition(ast, 'children.0.markup.variable.name');
+              } else {
+                expectPath(ast, 'children.0.markup.variable').to.equal(null);
+              }
+              expectPath(ast, 'children.0.markup.alias').to.equal(alias);
+              expectPath(ast, 'children.0.markup.args').to.have.lengthOf(namedArguments.length);
+              namedArguments.forEach(({ name, valueType }, i) => {
+                expectPath(ast, `children.0.markup.args.${i}.type`).to.equal('NamedArgument');
+                expectPath(ast, `children.0.markup.args.${i}.name`).to.equal(name);
+                expectPath(ast, `children.0.markup.args.${i}.value.type`).to.equal(valueType);
+                expectPosition(ast, `children.0.markup.args.${i}`);
+                expectPosition(ast, `children.0.markup.args.${i}.value`);
+              });
+              expectPath(ast, 'children.0.whitespaceStart').to.equal('');
+              expectPath(ast, 'children.0.whitespaceEnd').to.equal('-');
+              expectPosition(ast, 'children.0');
+              expectPosition(ast, 'children.0.markup');
+            },
+          );
+        });
+
+        it('should parse conditional tags into conditional expressions', () => {
+          ['if', 'unless'].forEach((tagName) => {
+            [
+              {
+                expression: 'a',
+                markup: {
+                  type: 'VariableLookup',
+                },
+              },
+              {
+                expression: 'a and "string"',
+                markup: {
+                  type: 'LogicalExpression',
+                  relation: 'and',
+                  left: { type: 'VariableLookup' },
+                  right: { type: 'String' },
+                },
+              },
+              {
+                expression: 'a and "string" or a<1',
+                markup: {
+                  type: 'LogicalExpression',
+                  relation: 'and',
+                  left: { type: 'VariableLookup' },
+                  right: {
+                    type: 'LogicalExpression',
+                    relation: 'or',
+                    left: { type: 'String' },
+                    right: {
+                      type: 'Comparison',
+                      comparator: '<',
+                      left: { type: 'VariableLookup' },
+                      right: { type: 'Number' },
+                    },
+                  },
+                },
+              },
+            ].forEach(({ expression, markup }) => {
+              ast = toAST(`{% ${tagName} ${expression} -%}{% end${tagName} %}`);
+              expectPath(ast, 'children.0.type').to.equal('LiquidTag');
+              expectPath(ast, 'children.0.name').to.equal(tagName);
+              let cursor: any = markup;
+              let prefix = '';
+              while (cursor) {
+                switch (cursor.type) {
+                  case 'LogicalExpression': {
+                    expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
+                    expectPath(ast, `children.0.markup${prefix}.relation`).to.equal(
+                      cursor.relation,
+                    );
+                    expectPath(ast, `children.0.markup${prefix}.left.type`).to.equal(
+                      cursor.left.type,
+                    );
+                    cursor = cursor.right;
+                    prefix = prefix + '.right';
+                    break;
+                  }
+                  case 'Comparison': {
+                    expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
+                    expectPath(ast, `children.0.markup${prefix}.comparator`).to.equal(
+                      cursor.comparator,
+                    );
+                    expectPath(ast, `children.0.markup${prefix}.left.type`).to.equal(
+                      cursor.left.type,
+                    );
+                    expectPath(ast, `children.0.markup${prefix}.right.type`).to.equal(
+                      cursor.right.type,
+                    );
+                    cursor = cursor.right;
+                    prefix = prefix + '.right';
+                    break;
+                  }
+                  default: {
+                    expectPath(ast, `children.0.markup${prefix}.type`).to.equal(cursor.type);
+                    cursor = null;
+                    break;
+                  }
+                }
+              }
+
+              expectPosition(ast, 'children.0');
+            });
+          });
+        });
+      });
+
+      it(`${title} - should parse liquid inline comments`, () => {
+        ast = toAST(`{% #%}`);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+        expectPath(ast, 'children.0.name').to.eql('#');
+        expectPath(ast, 'children.0.markup').to.eql('');
+
+        ast = toAST(`{% #hello world %}`);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+        expectPath(ast, 'children.0.name').to.eql('#');
+        expectPath(ast, 'children.0.markup').to.eql('hello world');
+      });
+
+      it(`${title} - should parse liquid case as branches`, () => {
+        ast = toAST(`{% case A %}{% when A %}A{% when "B" %}B{% else %}C{% endcase %}`);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+        expectPath(ast, 'children.0.name').to.eql('case');
+
+        // There's an empty child node between the case and first when. That's OK (?)
+        // What if there's whitespace? I think that's a printer problem. If
+        // there's freeform text we should somehow catch it.
+        expectPath(ast, 'children.0.children.0').to.exist;
+        expectPath(ast, 'children.0.children.0.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.0.name').to.eql(null);
+
+        expectPath(ast, 'children.0.children.1').to.exist;
+        expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.1.name').to.eql('when');
+        expectPath(ast, 'children.0.children.1.markup').to.have.lengthOf(1);
+        expectPath(ast, 'children.0.children.1.markup.0.type').to.equal('VariableLookup');
+        expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.1.children.0.value').to.eql('A');
+
+        expectPath(ast, 'children.0.children.2.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.2.name').to.eql('when');
+        expectPath(ast, 'children.0.children.2.markup.0.type').to.equal('String');
+        expectPath(ast, 'children.0.children.2.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.2.children.0.value').to.eql('B');
+
+        expectPath(ast, 'children.0.children.3.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.3.name').to.eql('else');
+        expectPath(ast, 'children.0.children.3.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.3.children.0.value').to.eql('C');
+      });
+
+      it(`${title} - should parse liquid ifs as branches`, () => {
+        ast = toAST(`{% if A %}A{% elsif B %}B{% else %}C{% endif %}`);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+        expectPath(ast, 'children.0.name').to.eql('if');
+        expectPath(ast, 'children.0.children.0').to.exist;
+        expectPath(ast, 'children.0.children.0.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.0.name').to.eql(null);
+        expectPath(ast, 'children.0.children.0.markup').to.eql('');
+        expectPath(ast, 'children.0.children.0.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.0.children.0.value').to.eql('A');
+
+        expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.1.name').to.eql('elsif');
+        expectPath(ast, 'children.0.children.1.markup.type').to.eql('VariableLookup');
+        expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.1.children.0.value').to.eql('B');
+
+        expectPath(ast, 'children.0.children.2.type').to.eql('LiquidBranch');
+        expectPath(ast, 'children.0.children.2.name').to.eql('else');
+        expectPath(ast, 'children.0.children.2.children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.children.2.children.0.value').to.eql('C');
+      });
+
+      it(`${title} - should parse a basic text node into a TextNode`, () => {
+        ast = toAST('Hello world!');
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.value').to.eql('Hello world!');
+        expectPosition(ast, 'children.0');
       });
     });
   });
 
-  it('should parse a basic text node into a TextNode', () => {
-    ast = toLiquidHtmlAST('Hello world!');
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.value').to.eql('Hello world!');
-    expectPosition(ast, 'children.0');
-  });
+  describe('Unit: toLiquidHtmlAST(text)', () => {
+    let ast: any;
 
-  it('should parse HTML attributes', () => {
-    ast = toLiquidHtmlAST(`<img src="https://1234" loading='lazy' disabled checked="">`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('HtmlVoidElement');
-    expectPath(ast, 'children.0.name').to.eql('img');
-    expectPath(ast, 'children.0.attributes.0.name.0.value').to.eql('src');
-    expectPath(ast, 'children.0.attributes.0.value.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.attributes.0.value.0.value').to.eql('https://1234');
-    expectPath(ast, 'children.0.attributes.1.name.0.value').to.eql('loading');
-    expectPath(ast, 'children.0.attributes.1.value.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.attributes.1.value.0.value').to.eql('lazy');
-    expectPath(ast, 'children.0.attributes.2.name.0.value').to.eql('disabled');
-    expectPath(ast, 'children.0.attributes.3.name.0.value').to.eql('checked');
-    expectPath(ast, 'children.0.attributes.3.value.0').to.be.undefined;
-
-    expectPosition(ast, 'children.0');
-    expectPosition(ast, 'children.0.attributes.0');
-    expectPosition(ast, 'children.0.attributes.0.value.0');
-    expectPosition(ast, 'children.0.attributes.1');
-    expectPosition(ast, 'children.0.attributes.1.value.0');
-    expectPosition(ast, 'children.0.attributes.2');
-  });
-
-  it('should parse HTML attributes inside tags', () => {
-    ast = toLiquidHtmlAST(
-      `<img {% if cond %}src="https://1234" loading='lazy'{% else %}disabled{% endif %}>`,
-    );
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('HtmlVoidElement');
-    expectPath(ast, 'children.0.name').to.eql('img');
-    expectPath(ast, 'children.0.attributes.0.name').to.eql('if');
-    expectPath(ast, 'children.0.attributes.0.children.0.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.attributes.0.children.0.children.0.type').to.eql(
-      'AttrDoubleQuoted',
-    );
-    expectPath(ast, 'children.0.attributes.0.children.0.children.1.type').to.eql(
-      'AttrSingleQuoted',
-    );
-  });
-
-  it('should parse HTML tags with Liquid Drop names', () => {
-    [
-      `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{node_type}}>`,
-      `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{ node_type }}>`,
-      `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{- node_type }}>`,
-      `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
-      `<{{ node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
-      `<{{ node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
-      `<{{- node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
-    ].forEach((testCase) => {
-      ast = toLiquidHtmlAST(testCase);
+    it('should parse HTML attributes', () => {
+      ast = toLiquidHtmlAST(`<img src="https://1234" loading='lazy' disabled checked="">`);
       expectPath(ast, 'children.0').to.exist;
-      expectPath(ast, 'children.0.type').to.eql('HtmlElement');
-      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
-      expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
-      expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
+      expectPath(ast, 'children.0.type').to.eql('HtmlVoidElement');
+      expectPath(ast, 'children.0.name').to.eql('img');
       expectPath(ast, 'children.0.attributes.0.name.0.value').to.eql('src');
       expectPath(ast, 'children.0.attributes.0.value.0.type').to.eql('TextNode');
       expectPath(ast, 'children.0.attributes.0.value.0.value').to.eql('https://1234');
@@ -589,193 +653,259 @@ describe('Unit: toLiquidHtmlAST', () => {
       expectPath(ast, 'children.0.attributes.1.value.0.type').to.eql('TextNode');
       expectPath(ast, 'children.0.attributes.1.value.0.value').to.eql('lazy');
       expectPath(ast, 'children.0.attributes.2.name.0.value').to.eql('disabled');
+      expectPath(ast, 'children.0.attributes.3.name.0.value').to.eql('checked');
+      expectPath(ast, 'children.0.attributes.3.value.0').to.be.undefined;
+
+      expectPosition(ast, 'children.0');
+      expectPosition(ast, 'children.0.attributes.0');
+      expectPosition(ast, 'children.0.attributes.0.value.0');
+      expectPosition(ast, 'children.0.attributes.1');
+      expectPosition(ast, 'children.0.attributes.1.value.0');
+      expectPosition(ast, 'children.0.attributes.2');
+    });
+
+    it('should parse HTML attributes inside tags', () => {
+      ast = toLiquidHtmlAST(
+        `<img {% if cond %}src="https://1234" loading='lazy'{% else %}disabled{% endif %}>`,
+      );
+      expectPath(ast, 'children.0').to.exist;
+      expectPath(ast, 'children.0.type').to.eql('HtmlVoidElement');
+      expectPath(ast, 'children.0.name').to.eql('img');
+      expectPath(ast, 'children.0.attributes.0.name').to.eql('if');
+      expectPath(ast, 'children.0.attributes.0.children.0.type').to.eql('LiquidBranch');
+      expectPath(ast, 'children.0.attributes.0.children.0.children.0.type').to.eql(
+        'AttrDoubleQuoted',
+      );
+      expectPath(ast, 'children.0.attributes.0.children.0.children.1.type').to.eql(
+        'AttrSingleQuoted',
+      );
+    });
+
+    it('should parse HTML tags with Liquid Drop names', () => {
+      [
+        `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{node_type}}>`,
+        `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{ node_type }}>`,
+        `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{- node_type }}>`,
+        `<{{ node_type }} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
+        `<{{ node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
+        `<{{ node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
+        `<{{- node_type -}} src="https://1234" loading='lazy' disabled></{{- node_type -}}>`,
+      ].forEach((testCase) => {
+        ast = toLiquidHtmlAST(testCase);
+        expectPath(ast, 'children.0').to.exist;
+        expectPath(ast, 'children.0.type').to.eql('HtmlElement');
+        expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+        expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
+        expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
+        expectPath(ast, 'children.0.attributes.0.name.0.value').to.eql('src');
+        expectPath(ast, 'children.0.attributes.0.value.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.attributes.0.value.0.value').to.eql('https://1234');
+        expectPath(ast, 'children.0.attributes.1.name.0.value').to.eql('loading');
+        expectPath(ast, 'children.0.attributes.1.value.0.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.attributes.1.value.0.value').to.eql('lazy');
+        expectPath(ast, 'children.0.attributes.2.name.0.value').to.eql('disabled');
+      });
+    });
+
+    it('should parse HTML tags with compound Liquid Drop names', () => {
+      ast = toLiquidHtmlAST(`<{{ node_type }}--header ></{{node_type}}--header>`);
+      expectPath(ast, 'children.0').to.exist;
+      expectPath(ast, 'children.0.type').to.eql('HtmlElement');
+      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+      expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
+      expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
+      expectPath(ast, 'children.0.name.1.value').to.eql('--header');
+    });
+
+    it('should parse HTML self-closing elements with compound Liquid Drop names', () => {
+      ast = toLiquidHtmlAST(`<{{ node_type }}--header />`);
+      expectPath(ast, 'children.0').to.exist;
+      expectPath(ast, 'children.0.type').to.eql('HtmlSelfClosingElement');
+      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+      expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
+      expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
+      expectPath(ast, 'children.0.name.1.value').to.eql('--header');
+    });
+
+    it('should throw when trying to close the wrong node', () => {
+      const testCases = [
+        '<a><div></a>',
+        '<a>{% if condition %}</a>',
+        '{% for a in b %}<div>{% endfor %}',
+        '{% for a in b %}{% if condition %}{% endfor %}',
+        '<{{ node_type }}><div></{{ node_type }}>',
+        '<{{ node_type }}></{{ wrong_end_node }}>',
+      ];
+      for (const testCase of testCases) {
+        try {
+          toLiquidHtmlAST(testCase);
+          expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+        } catch (e: any) {
+          expect(e.name).to.eql('LiquidHTMLParsingError');
+          expect(e.message).to.match(
+            /Attempting to close \w+ '[^']+' before \w+ '[^']+' was closed/,
+          );
+          expect(e.message).not.to.match(/undefined/i);
+          expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+        }
+      }
+    });
+
+    it('should throw when closing at the top level', () => {
+      const testCases = ['<a>', '{% if %}'];
+      for (const testCase of testCases) {
+        try {
+          toLiquidHtmlAST(testCase);
+          expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+        } catch (e: any) {
+          expect(e.name).to.eql('LiquidHTMLParsingError');
+          expect(e.message).to.match(/Attempting to end parsing before \w+ '[^']+' was closed/);
+          expect(e.message).not.to.match(/undefined/i);
+          expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+        }
+      }
+    });
+
+    it('should throw when forgetting to close', () => {
+      const testCases = ['</a>', '{% endif %}'];
+      for (const testCase of testCases) {
+        try {
+          toLiquidHtmlAST(testCase);
+          expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
+        } catch (e: any) {
+          expect(e.name).to.eql('LiquidHTMLParsingError');
+          expect(e.message).to.match(/Attempting to close \w+ '[^']+' before it was opened/);
+          expect(e.message).not.to.match(/undefined/i);
+          expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+        }
+      }
+    });
+
+    it('should throw when trying to end doc with unclosed nodes', () => {
+      const testCases = ['<p><div>', '{% if condition %}', '<script>', '<{{ node_type }}>'];
+      for (const testCase of testCases) {
+        try {
+          toLiquidHtmlAST(testCase);
+          expect(true, `expected ${testCase} to throw LiquidHTMLASTParsingError`).to.be.false;
+        } catch (e: any) {
+          if (e.name === 'AssertionError') {
+            console.log(e);
+          }
+          expect(e.name).to.eql('LiquidHTMLParsingError');
+          expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
+        }
+      }
+    });
+
+    it('should parse html comments as raw', () => {
+      ast = toLiquidHtmlAST(`<!--\n  hello {{ product.name }}\n-->`);
+      expectPath(ast, 'children.0.type').to.eql('HtmlComment');
+      expectPath(ast, 'children.0.body').to.eql('hello {{ product.name }}');
+      expectPosition(ast, 'children.0');
+    });
+
+    it('should parse script tags as raw', () => {
+      ast = toLiquidHtmlAST(`<script>\n  const a = {{ product | json }};\n</script>`);
+      expectPath(ast, 'children.0.type').to.eql('HtmlRawNode');
+      expectPath(ast, 'children.0.name').to.eql('script');
+      expectPath(ast, 'children.0.body.type').to.eql('RawMarkup');
+      expectPath(ast, 'children.0.body.kind').to.eql('javascript');
+      expectPath(ast, 'children.0.body.value').to.eql('\n  const a = {{ product | json }};\n');
+      expectPosition(ast, 'children.0');
+    });
+
+    it('should parse style tags as raw markup', () => {
+      ast = toLiquidHtmlAST(`<style>\n  :root { --bg: {{ settings.bg }}}\n</style>`);
+      expectPath(ast, 'children.0.type').to.eql('HtmlRawNode');
+      expectPath(ast, 'children.0.name').to.eql('style');
+      expectPath(ast, 'children.0.body.type').to.eql('RawMarkup');
+      expectPath(ast, 'children.0.body.kind').to.eql('text');
+      expectPath(ast, 'children.0.body.value').to.eql('\n  :root { --bg: {{ settings.bg }}}\n');
+      expectPosition(ast, 'children.0');
     });
   });
 
-  it('should parse HTML tags with compound Liquid Drop names', () => {
-    ast = toLiquidHtmlAST(`<{{ node_type }}--header ></{{node_type}}--header>`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('HtmlElement');
-    expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
-    expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
-    expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
-    expectPath(ast, 'children.0.name.1.value').to.eql('--header');
-  });
+  describe('Unit: toLiquidAST(text)', () => {
+    let ast: any;
 
-  it('should parse HTML self-closing elements with compound Liquid Drop names', () => {
-    ast = toLiquidHtmlAST(`<{{ node_type }}--header />`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('HtmlSelfClosingElement');
-    expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
-    expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
-    expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
-    expectPath(ast, 'children.0.name.1.value').to.eql('--header');
-  });
+    it('should parse nested unclosed tags', () => {
+      ast = toLiquidAST('{% for a in b %} <div> {% if true %}');
 
-  it('should throw when trying to close the wrong node', () => {
-    const testCases = [
-      '<a><div></a>',
-      '<a>{% if condition %}</a>',
-      '{% for a in b %}<div>{% endfor %}',
-      '{% for a in b %}{% if condition %}{% endfor %}',
-      '<{{ node_type }}><div></{{ node_type }}>',
-      '<{{ node_type }}></{{ wrong_end_node }}>',
-    ];
-    for (const testCase of testCases) {
-      try {
-        toLiquidHtmlAST(testCase);
-        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
-      } catch (e) {
-        expect(e.name).to.eql('LiquidHTMLParsingError');
-        expect(e.message).to.match(/Attempting to close \w+ '[^']+' before \w+ '[^']+' was closed/);
-        expect(e.message).not.to.match(/undefined/i);
-        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
-      }
-    }
-  });
+      expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.name').to.eql('for');
 
-  it('should throw when closing at the top level', () => {
-    const testCases = ['<a>', '{% if %}'];
-    for (const testCase of testCases) {
-      try {
-        toLiquidHtmlAST(testCase);
-        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
-      } catch (e) {
-        expect(e.name).to.eql('LiquidHTMLParsingError');
-        expect(e.message).to.match(/Attempting to end parsing before \w+ '[^']+' was closed/);
-        expect(e.message).not.to.match(/undefined/i);
-        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
-      }
-    }
-  });
+      expectPath(ast, 'children.0.children.0.children.0.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.children.0.children.0.value').to.eql('<div>');
 
-  it('should throw when forgetting to close', () => {
-    const testCases = ['</a>', '{% endif %}'];
-    for (const testCase of testCases) {
-      try {
-        toLiquidHtmlAST(testCase);
-        expect(true, `expected ${testCase} to throw LiquidHTMLCSTParsingError`).to.be.false;
-      } catch (e) {
-        expect(e.name).to.eql('LiquidHTMLParsingError');
-        expect(e.message).to.match(/Attempting to close \w+ '[^']+' before it was opened/);
-        expect(e.message).not.to.match(/undefined/i);
-        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
-      }
-    }
-  });
+      expectPath(ast, 'children.0.children.0.children.1.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.children.0.children.1.name').to.eql('if');
+    });
 
-  it('should throw when trying to end doc with unclosed nodes', () => {
-    const testCases = ['<p><div>', '{% if condition %}', '<script>', '<{{ node_type }}>'];
-    for (const testCase of testCases) {
-      try {
-        toLiquidHtmlAST(testCase);
-        expect(true, `expected ${testCase} to throw LiquidHTMLASTParsingError`).to.be.false;
-      } catch (e) {
-        if (e.name === 'AssertionError') {
-          console.log(e);
-        }
-        expect(e.name).to.eql('LiquidHTMLParsingError');
-        expect(e.loc, `expected ${e} to have location information`).not.to.be.undefined;
-      }
-    }
-  });
+    it('should parse unclosed conditions with assignments', () => {
+      ast = toLiquidAST(`
+        {%- liquid
+          assign var1 = product
 
-  it('should parse html comments as raw', () => {
-    ast = toLiquidHtmlAST(`<!--\n  hello {{ product.name }}\n-->`);
-    expectPath(ast, 'children.0.type').to.eql('HtmlComment');
-    expectPath(ast, 'children.0.body').to.eql('hello {{ product.name }}');
-    expectPosition(ast, 'children.0');
-  });
+          if use_variant
+            assign var2 = var1
+            assign var3 = var2
+        -%}
+      `);
 
-  it('should parse script tags as raw', () => {
-    ast = toLiquidHtmlAST(`<script>\n  const a = {{ product | json }};\n</script>`);
-    expectPath(ast, 'children.0.type').to.eql('HtmlRawNode');
-    expectPath(ast, 'children.0.name').to.eql('script');
-    expectPath(ast, 'children.0.body.type').to.eql('RawMarkup');
-    expectPath(ast, 'children.0.body.kind').to.eql('javascript');
-    expectPath(ast, 'children.0.body.value').to.eql('\n  const a = {{ product | json }};\n');
-    expectPosition(ast, 'children.0');
-  });
+      expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.name').to.eql('liquid');
 
-  it('should parse style tags as raw markup', () => {
-    ast = toLiquidHtmlAST(`<style>\n  :root { --bg: {{ settings.bg }}}\n</style>`);
-    expectPath(ast, 'children.0.type').to.eql('HtmlRawNode');
-    expectPath(ast, 'children.0.name').to.eql('style');
-    expectPath(ast, 'children.0.body.type').to.eql('RawMarkup');
-    expectPath(ast, 'children.0.body.kind').to.eql('text');
-    expectPath(ast, 'children.0.body.value').to.eql('\n  :root { --bg: {{ settings.bg }}}\n');
-    expectPosition(ast, 'children.0');
-  });
+      expectPath(ast, 'children.0.markup.0.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.markup.0.name').to.eql('assign');
+      expectPath(ast, 'children.0.markup.0.markup.name').to.eql('var1');
 
-  it('should parse liquid ifs as branches', () => {
-    ast = toLiquidHtmlAST(`{% if A %}A{% elsif B %}B{% else %}C{% endif %}`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-    expectPath(ast, 'children.0.name').to.eql('if');
-    expectPath(ast, 'children.0.children.0').to.exist;
-    expectPath(ast, 'children.0.children.0.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.0.name').to.eql(null);
-    expectPath(ast, 'children.0.children.0.markup').to.eql('');
-    expectPath(ast, 'children.0.children.0.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.0.children.0.value').to.eql('A');
+      expectPath(ast, 'children.0.markup.1.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.markup.1.name').to.eql('if');
 
-    expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.1.name').to.eql('elsif');
-    expectPath(ast, 'children.0.children.1.markup.type').to.eql('VariableLookup');
-    expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.1.children.0.value').to.eql('B');
+      expectPath(ast, 'children.0.markup.1.children.0.children.0.name').to.eql('assign');
+      expectPath(ast, 'children.0.markup.1.children.0.children.0.markup.name').to.eql('var2');
 
-    expectPath(ast, 'children.0.children.2.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.2.name').to.eql('else');
-    expectPath(ast, 'children.0.children.2.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.2.children.0.value').to.eql('C');
-  });
+      expectPath(ast, 'children.0.markup.1.children.0.children.1.name').to.eql('assign');
+      expectPath(ast, 'children.0.markup.1.children.0.children.1.markup.name').to.eql('var3');
+    });
 
-  it('should parse liquid case as branches', () => {
-    ast = toLiquidHtmlAST(`{% case A %}{% when A %}A{% when "B" %}B{% else %}C{% endcase %}`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-    expectPath(ast, 'children.0.name').to.eql('case');
+    it('should parse unclosed tables with assignments', () => {
+      ast = toLiquidAST(`
+        {%- liquid
+          assign var1 = product
+        -%}
+        <table>
+          {% tablerow var2 in collections.first.products %}
+            {% assign var3 = var2 %}
+            {{ var3.title }}
+      `);
 
-    // There's an empty child node between the case and first when. That's OK (?)
-    // What if there's whitespace? I think that's a printer problem. If
-    // there's freeform text we should somehow catch it.
-    expectPath(ast, 'children.0.children.0').to.exist;
-    expectPath(ast, 'children.0.children.0.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.0.name').to.eql(null);
+      expectPath(ast, 'children.0.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.name').to.eql('liquid');
+      expectPath(ast, 'children.0.markup.0.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.0.markup.0.name').to.eql('assign');
+      expectPath(ast, 'children.0.markup.0.markup.name').to.eql('var1');
 
-    expectPath(ast, 'children.0.children.1').to.exist;
-    expectPath(ast, 'children.0.children.1.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.1.name').to.eql('when');
-    expectPath(ast, 'children.0.children.1.markup').to.have.lengthOf(1);
-    expectPath(ast, 'children.0.children.1.markup.0.type').to.equal('VariableLookup');
-    expectPath(ast, 'children.0.children.1.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.1.children.0.value').to.eql('A');
+      expectPath(ast, 'children.1.type').to.eql('TextNode');
+      expectPath(ast, 'children.1.value').to.eql('<table>');
 
-    expectPath(ast, 'children.0.children.2.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.2.name').to.eql('when');
-    expectPath(ast, 'children.0.children.2.markup.0.type').to.equal('String');
-    expectPath(ast, 'children.0.children.2.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.2.children.0.value').to.eql('B');
+      expectPath(ast, 'children.2.type').to.eql('LiquidTag');
+      expectPath(ast, 'children.2.name').to.eql('tablerow');
+    });
 
-    expectPath(ast, 'children.0.children.3.type').to.eql('LiquidBranch');
-    expectPath(ast, 'children.0.children.3.name').to.eql('else');
-    expectPath(ast, 'children.0.children.3.children.0.type').to.eql('TextNode');
-    expectPath(ast, 'children.0.children.3.children.0.value').to.eql('C');
-  });
+    it('should parse script tags as a text node', () => {
+      ast = toLiquidAST(`<script>\n  const a = {{ product | json }};\n</script>`);
 
-  it('should parse liquid inline comments', () => {
-    ast = toLiquidHtmlAST(`{% #%}`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-    expectPath(ast, 'children.0.name').to.eql('#');
-    expectPath(ast, 'children.0.markup').to.eql('');
+      expectPath(ast, 'children.0.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.value').to.eql('<script>\n  const a =');
+    });
 
-    ast = toLiquidHtmlAST(`{% #hello world %}`);
-    expectPath(ast, 'children.0').to.exist;
-    expectPath(ast, 'children.0.type').to.eql('LiquidTag');
-    expectPath(ast, 'children.0.name').to.eql('#');
-    expectPath(ast, 'children.0.markup').to.eql('hello world');
+    it('should parse style tags as a text node', () => {
+      ast = toLiquidAST(`<style>\n  :root { --bg: {{ settings.bg }}}\n</style>`);
+
+      expectPath(ast, 'children.0.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.value').to.eql('<style>\n  :root { --bg:');
+    });
   });
 
   function expectPath(ast: LiquidHtmlNode, path: string) {
@@ -785,9 +915,5 @@ describe('Unit: toLiquidHtmlAST', () => {
   function expectPosition(ast: LiquidHtmlNode, path: string) {
     expectPath(ast, path + '.position.start').to.be.a('number');
     expectPath(ast, path + '.position.end').to.be.a('number');
-  }
-
-  function sourceExcerpt(node: LiquidHtmlNode) {
-    return node.source.slice(node.position.start, node.position.end);
   }
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR introduces support to broken templates in the Liquid parser. In other words, this PR makes [this unit](https://github.com/Shopify/prettier-plugin-liquid/blob/fix/12-lls-support-to-broken-liquid/src/parser/stage-2-ast.spec.ts#L872-L894) pass:

```typescript
it('should parse unclosed tables with assignments', () => {
  ast = toLiquidAST(`
    {%- liquid
      assign var1 = product
    -%}
    <table>
      {% tablerow var2 in collections.first.products %}
        {% assign var3 = var2 %}
        {{ var3.title }}
  `);

  expectPath(ast, 'children.0.type').to.eql('LiquidTag');
  expectPath(ast, 'children.0.name').to.eql('liquid');
  expectPath(ast, 'children.0.markup.0.type').to.eql('LiquidTag');
  expectPath(ast, 'children.0.markup.0.name').to.eql('assign');
  expectPath(ast, 'children.0.markup.0.markup.name').to.eql('var1');

  expectPath(ast, 'children.1.type').to.eql('TextNode');
  expectPath(ast, 'children.1.value').to.eql('<table>');

  expectPath(ast, 'children.2.type').to.eql('LiquidTag');
  expectPath(ast, 'children.2.name').to.eql('tablerow');
});
```