### PR TITLE
Add support for strict Liquid parsing

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -45,11 +45,14 @@ Liquid <: Helpers {
     | liquidTag
     | liquidInlineComment
 
-  liquidTag =
+  liquidTagStrict =
     | liquidTagAssign
+    | liquidTagBreak
+    | liquidTagContinue
     | liquidTagCycle
     | liquidTagDecrement
     | liquidTagEcho
+    | liquidTagElse
     | liquidTagElsif
     | liquidTagInclude
     | liquidTagIncrement
@@ -59,9 +62,12 @@ Liquid <: Helpers {
     | liquidTagSection
     | liquidTagSections
     | liquidTagWhen
+
+  liquidTag =
+    | liquidTagStrict
     | liquidTagBaseCase
 
-  liquidTagOpen =
+  liquidTagOpenStrict =
     | liquidTagOpenCase
     | liquidTagOpenCapture
     | liquidTagOpenForm
@@ -70,7 +76,11 @@ Liquid <: Helpers {
     | liquidTagOpenIf
     | liquidTagOpenPaginate
     | liquidTagOpenUnless
+
+  liquidTagOpen =
+    | liquidTagOpenStrict
     | liquidTagOpenBaseCase
+
   liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
 
   // These two are the same but transformed differently
@@ -147,6 +157,10 @@ Liquid <: Helpers {
   liquidTagOpenIf = liquidTagOpenRule<"if", liquidTagOpenConditionalMarkup>
   liquidTagOpenUnless = liquidTagOpenRule<"unless", liquidTagOpenConditionalMarkup>
   liquidTagElsif = liquidTagRule<"elsif", liquidTagOpenConditionalMarkup>
+
+  liquidTagBreak = liquidTagRule<"break", empty>
+  liquidTagContinue = liquidTagRule<"continue", empty>
+  liquidTagElse = liquidTagRule<"else", empty>
 
   liquidTagOpenConditionalMarkup = nonemptyListOf<condition, conditionSeparator> space*
   conditionSeparator = &logicalOperator
@@ -454,4 +468,19 @@ LiquidHTML <: Liquid {
     | caseInsensitive<"track">
     | caseInsensitive<"wbr">
     ) ~identifierCharacter
+}
+
+StrictLiquid <: Liquid {
+  liquidTag := liquidTagStrict
+  liquidTagOpen := liquidTagOpenStrict
+}
+
+StrictLiquidStatement <: LiquidStatement {
+  liquidTag := liquidTagStrict
+  liquidTagOpen := liquidTagOpenStrict
+}
+
+StrictLiquidHTML <: LiquidHTML {
+  liquidTag := liquidTagStrict
+  liquidTagOpen := liquidTagOpenStrict
 }

--- a/src/parser/grammar.spec.ts
+++ b/src/parser/grammar.spec.ts
@@ -1,89 +1,125 @@
 import { expect } from 'chai';
-import { liquidHtmlGrammar, liquidStatementsGrammar } from '~/parser/grammar';
+import { strictGrammars, tolerantGrammars } from '~/parser/grammar';
 
 describe('Unit: liquidHtmlGrammar', () => {
-  it('should parse or not parse HTML+Liquid', () => {
-    expectMatchSucceeded('<h6 data-src="hello world">').to.be.true;
-    expectMatchSucceeded('<a src="https://product"></a>').to.be.true;
-    expectMatchSucceeded('<a src="https://google.com"></b>').to.be.true;
-    expectMatchSucceeded(`<img src="hello" loading='lazy' enabled=true disabled>`).to.be.true;
-    expectMatchSucceeded(`<img src="hello" loading='lazy' enabled=true disabled />`).to.be.true;
-    expectMatchSucceeded(`<{{header_type}}-header>`).to.be.true;
-    expectMatchSucceeded(`<header--{{header_type}}>`).to.be.true;
-    expectMatchSucceeded(`<-nope>`).to.be.false;
-    expectMatchSucceeded(`<:nope>`).to.be.false;
-    expectMatchSucceeded(`<1nope>`).to.be.false;
-    expectMatchSucceeded(`{{ product.feature }}`).to.be.true;
-    expectMatchSucceeded(`{{product.feature}}`).to.be.true;
-    expectMatchSucceeded(`{%- if A -%}`).to.be.true;
-    expectMatchSucceeded(`{%-if A-%}`).to.be.true;
-    expectMatchSucceeded(`{%- else-%}`).to.be.true;
-    expectMatchSucceeded(`{%- liquid-%}`).to.be.true;
-    expectMatchSucceeded(`{%- schema-%}`).to.be.true;
-    expectMatchSucceeded(`{%- form-%}`).to.be.true;
-    expectMatchSucceeded(`{{ true-}}`).to.be.true;
-    expectMatchSucceeded(`
-      <html>
-        <head>
-          {{ 'foo' | script_tag }}
-        </head>
-        <body>
-          {% if true %}
-            <div>
-              hello world
-            </div>
-          {% else %}
-            nope
-          {% endif %}
-        </body>
-      </html>
-    `).to.be.true;
-    expectMatchSucceeded(`
-      <input
-        class="[[ cssClasses.checkbox ]] form-checkbox sm:text-[8px]"
-        type="checkbox"
+  const grammars = [
+    { mode: 'strict', grammar: strictGrammars },
+    { mode: 'tolerant', grammar: tolerantGrammars },
+  ];
 
-        [[# isRefined ]]
-          checked
-        [[/ isRefined ]]
-      />
-    `).to.be.true;
-    expectMatchSucceeded(`
-      <svg>
-          <svg a=1><svg b=2>
-            <path d="M12"></path>
-          </svg></svg>
-      </svg>
-    `).to.be.true;
-    expectMatchSucceeded(`<div data-popup-{{ section.id }}="size-{{ section.id }}">`).to.be.true;
-    expectMatchSucceeded('<img {% if aboveFold %} loading="lazy"{% endif %} />').to.be.true;
-    expectMatchSucceeded('<svg><use></svg>').to.be.true;
-    expectMatchSucceeded('<6h>').to.be.false;
+  grammars.forEach(({ mode, grammar }) => {
+    describe(`Case: ${mode}`, () => {
+      it('should parse or not parse HTML+Liquid', () => {
+        expectMatchSucceeded('<h6 data-src="hello world">').to.be.true;
+        expectMatchSucceeded('<a src="https://product"></a>').to.be.true;
+        expectMatchSucceeded('<a src="https://google.com"></b>').to.be.true;
+        expectMatchSucceeded(`<img src="hello" loading='lazy' enabled=true disabled>`).to.be.true;
+        expectMatchSucceeded(`<img src="hello" loading='lazy' enabled=true disabled />`).to.be.true;
+        expectMatchSucceeded(`<{{header_type}}-header>`).to.be.true;
+        expectMatchSucceeded(`<header--{{header_type}}>`).to.be.true;
+        expectMatchSucceeded(`<-nope>`).to.be.false;
+        expectMatchSucceeded(`<:nope>`).to.be.false;
+        expectMatchSucceeded(`<1nope>`).to.be.false;
+        expectMatchSucceeded(`{{ product.feature }}`).to.be.true;
+        expectMatchSucceeded(`{{product.feature}}`).to.be.true;
+        expectMatchSucceeded(`{%- if A -%}`).to.be.true;
+        expectMatchSucceeded(`{%-if A-%}`).to.be.true;
+        expectMatchSucceeded(`{%- else-%}`).to.be.true;
+        expectMatchSucceeded(`{%- break-%}`).to.be.true;
+        expectMatchSucceeded(`{%- continue -%}`).to.be.true;
+        expectMatchSucceeded(`{%- liquid-%}`).to.be.true;
+        expectMatchSucceeded(`{%- schema-%}{% endschema %}`).to.be.true;
+        expectMatchSucceeded(`{%- form 'form-type'-%}`).to.be.true;
+        expectMatchSucceeded(`{%- # a comment -%}`).to.be.true;
+        expectMatchSucceeded(`{%- javascript -%}{% endjavascript %}`).to.be.true;
+        expectMatchSucceeded(`{%- include 'layout' -%}`).to.be.true;
+        expectMatchSucceeded(`{%- layout 'full-width' -%}`).to.be.true;
+        expectMatchSucceeded(`{%- layout none -%}`).to.be.true;
+        expectMatchSucceeded(`{% render 'filename' for array as item %}`).to.be.true;
+        expectMatchSucceeded(`{% section 'name' %}`).to.be.true;
+        expectMatchSucceeded(`{% sections 'name' %}`).to.be.true;
+        expectMatchSucceeded(`{% style %}{% endstyle %}`).to.be.true;
+        expectMatchSucceeded(`{% stylesheet %}{% endstylesheet %}`).to.be.true;
+        expectMatchSucceeded(`{% assign variable_name = value %}`).to.be.true;
+        expectMatchSucceeded(`
+          {% capture variable %}
+            value
+          {% endcapture %}
+        `).to.be.true;
+        expectMatchSucceeded(`
+          {% for variable in array limit: number %}
+            expression
+          {% endfor %}
+        `).to.be.true;
 
-    function expectMatchSucceeded(text: string) {
-      const match = liquidHtmlGrammar.match(text, 'Node');
-      return expect(match.succeeded());
-    }
-  });
+        expectMatchSucceeded(`{% decrement variable_name %}`).to.be.true;
+        expectMatchSucceeded(`{% increment variable_name %}`).to.be.true;
+        expectMatchSucceeded(`{{ true-}}`).to.be.true;
+        expectMatchSucceeded(`
+          <html>
+            <head>
+              {{ 'foo' | script_tag }}
+            </head>
+            <body>
+              {% if true %}
+                <div>
+                  hello world
+                </div>
+              {% else %}
+                nope
+              {% endif %}
+            </body>
+          </html>
+        `).to.be.true;
+        expectMatchSucceeded(`
+          <input
+            class="[[ cssClasses.checkbox ]] form-checkbox sm:text-[8px]"
+            type="checkbox"
 
-  it('should parse or not parse {% liquid %} lines', () => {
-    expectMatchSucceeded(`
-      layout none
+            [[# isRefined ]]
+              checked
+            [[/ isRefined ]]
+          />
+        `).to.be.true;
+        expectMatchSucceeded(`
+          <svg>
+              <svg a=1><svg b=2>
+                <path d="M12"></path>
+              </svg></svg>
+          </svg>
+        `).to.be.true;
+        expectMatchSucceeded(`<div data-popup-{{ section.id }}="size-{{ section.id }}">`).to.be
+          .true;
+        expectMatchSucceeded('<img {% if aboveFold %} loading="lazy"{% endif %} />').to.be.true;
+        expectMatchSucceeded('<svg><use></svg>').to.be.true;
+        expectMatchSucceeded('<6h>').to.be.false;
 
-      paginate search.results by 28
-        for item in search.results
-          if item.object_type != 'product'
-            continue
-          endif
+        function expectMatchSucceeded(text: string) {
+          const match = grammar.LiquidHTML.match(text, 'Node');
+          return expect(match.succeeded(), text);
+        }
+      });
 
-          render 'product-item', product: item
-        endfor
-      endpaginate
-    `).to.be.true;
+      it('should parse or not parse {% liquid %} lines', () => {
+        expectMatchSucceeded(`
+          layout none
 
-    function expectMatchSucceeded(text: string) {
-      const match = liquidStatementsGrammar.match(text.trimStart(), 'Node');
-      return expect(match.succeeded());
-    }
+          paginate search.results by 28
+            for item in search.results
+              if item.object_type != 'product'
+                continue
+              endif
+
+              render 'product-item', product: item
+            endfor
+          endpaginate
+        `).to.be.true;
+
+        function expectMatchSucceeded(text: string) {
+          const match = grammar.LiquidStatement.match(text.trimStart(), 'Node');
+          return expect(match.succeeded(), text);
+        }
+      });
+    });
   });
 });

--- a/src/parser/grammar.ts
+++ b/src/parser/grammar.ts
@@ -4,18 +4,26 @@ export const liquidHtmlGrammars = ohm.grammars(
   require('../../grammar/liquid-html.ohm.js'),
 );
 
-export const liquidGrammar = liquidHtmlGrammars['Liquid'];
-export const liquidHtmlGrammar = liquidHtmlGrammars['LiquidHTML'];
-export const liquidStatementsGrammar = liquidHtmlGrammars['LiquidStatement'];
+export const strictGrammars = {
+  Liquid: liquidHtmlGrammars['StrictLiquid'],
+  LiquidHTML: liquidHtmlGrammars['StrictLiquidHTML'],
+  LiquidStatement: liquidHtmlGrammars['StrictLiquidStatement'],
+};
+
+export const tolerantGrammars = {
+  Liquid: liquidHtmlGrammars['Liquid'],
+  LiquidHTML: liquidHtmlGrammars['LiquidHTML'],
+  LiquidStatement: liquidHtmlGrammars['LiquidStatement'],
+};
 
 // see ../../grammar/liquid-html.ohm for full list
 export const BLOCKS = (
-  liquidHtmlGrammar.rules as any
+  strictGrammars.LiquidHTML.rules as any
 ).blockName.body.factors[0].terms.map((x: any) => x.obj) as string[];
 
 // see ../../grammar/liquid-html.ohm for full list
 export const VOID_ELEMENTS = (
-  liquidHtmlGrammar.rules as any
+  strictGrammars.LiquidHTML.rules as any
 ).voidElementName.body.factors[0].terms.map(
   (x: any) => x.args[0].obj,
 ) as string[];

--- a/src/parser/stage-2-ast.spec.ts
+++ b/src/parser/stage-2-ast.spec.ts
@@ -571,7 +571,7 @@ describe('Unit: Stage 2 (AST)', () => {
       });
 
       it(`${title} - should parse liquid case as branches`, () => {
-        ast = toAST(`{% case A %}{% when A %}A{% when "B" %}B{% else %}C{% endcase %}`);
+        ast = toAST(`{% case A %}{% when A %}A{% when "B" %}B{% else    %}C{% endcase %}`);
         expectPath(ast, 'children.0').to.exist;
         expectPath(ast, 'children.0.type').to.eql('LiquidTag');
         expectPath(ast, 'children.0.name').to.eql('case');
@@ -599,6 +599,7 @@ describe('Unit: Stage 2 (AST)', () => {
 
         expectPath(ast, 'children.0.children.3.type').to.eql('LiquidBranch');
         expectPath(ast, 'children.0.children.3.name').to.eql('else');
+        expectPath(ast, 'children.0.children.3.markup').to.eql('');
         expectPath(ast, 'children.0.children.3.children.0.type').to.eql('TextNode');
         expectPath(ast, 'children.0.children.3.children.0.value').to.eql('C');
       });

--- a/test/liquid-tag-break/fixed.liquid
+++ b/test/liquid-tag-break/fixed.liquid
@@ -1,0 +1,17 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% for i in col %}
+  {% break %}
+{% endfor %}
+
+It should support missing whitespace
+printWidth: 1
+{% for i in col %}
+  {%- break -%}
+{% endfor %}
+
+It should strip extraneous args
+printWidth: 1
+{% for i in col %}
+  {% break %}
+{% endfor %}

--- a/test/liquid-tag-break/index.liquid
+++ b/test/liquid-tag-break/index.liquid
@@ -1,0 +1,11 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% for i in col %} {% break   %} {% endfor %}
+
+It should support missing whitespace
+printWidth: 1
+{% for i in col %} {%-break-%} {% endfor %}
+
+It should strip extraneous args
+printWidth: 1
+{% for i in col %} {% break huh?? %} {% endfor %}

--- a/test/liquid-tag-break/index.spec.ts
+++ b/test/liquid-tag-break/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-continue/fixed.liquid
+++ b/test/liquid-tag-continue/fixed.liquid
@@ -1,0 +1,17 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% for i in col %}
+  {% continue %}
+{% endfor %}
+
+It should support missing whitespace
+printWidth: 1
+{% for i in col %}
+  {%- continue -%}
+{% endfor %}
+
+It should strip extraneous args
+printWidth: 1
+{% for i in col %}
+  {% continue %}
+{% endfor %}

--- a/test/liquid-tag-continue/index.liquid
+++ b/test/liquid-tag-continue/index.liquid
@@ -1,0 +1,11 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% for i in col %} {% continue   %} {% endfor %}
+
+It should support missing whitespace
+printWidth: 1
+{% for i in col %} {%-continue-%} {% endfor %}
+
+It should strip extraneous args
+printWidth: 1
+{% for i in col %} {% continue huh?? %} {% endfor %}

--- a/test/liquid-tag-continue/index.spec.ts
+++ b/test/liquid-tag-continue/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});

--- a/test/liquid-tag-else/fixed.liquid
+++ b/test/liquid-tag-else/fixed.liquid
@@ -1,0 +1,20 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% if false %}
+{% else %}
+  hello
+{% endif %}
+
+It should support missing whitespace
+printWidth: 1
+{% if false %}
+{%- else -%}
+  hello
+{% endif %}
+
+It should strip extraneous args
+printWidth: 1
+{% if false %}
+{% else %}
+  hello
+{% endif %}

--- a/test/liquid-tag-else/index.liquid
+++ b/test/liquid-tag-else/index.liquid
@@ -1,0 +1,11 @@
+It should strip extraneous whitespace
+printWidth: 1
+{% if false %} {% else   %} hello {% endif %}
+
+It should support missing whitespace
+printWidth: 1
+{% if false %} {%-else-%} hello {% endif %}
+
+It should strip extraneous args
+printWidth: 1
+{% if false %} {% else huh??  %} hello {% endif %}

--- a/test/liquid-tag-else/index.spec.ts
+++ b/test/liquid-tag-else/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## In this PR

- Add support for Strict Liquid Markup parsing

## What this means

Right now, the `LiquidHTML` parser has default "fall through" cases for `liquidTagOpen` and `liquidTag`.

That is, we used to do something like this:

```
liquidTag = 
  | liquidTagAssign
  | liquidTagEcho
  | ...
  | liquidTagBaseCase
```

i.e., try the strict rule and, if that fails, parse the `.markup` as a string.

```
> toLiquidHTMLAST(`{% echo var %}`, { mode: 'tolerant' }) 
[
  {
    type: 'LiquidTag',
    name: 'echo',
    markup: {
      type: 'VariableLookup',
      expression: {/* ... /*}
      lookups: [],
    },
  }
]

> toLiquidHTMLAST(`{% echo var } error! { %}`, { mode: 'tolerant' }) 
[
  {
    type: 'LiquidTag',
    name: 'echo',
    markup: 'var } error! {', // this is a string
  }
]
```

With `{ mode: 'strict' }`, we'll throw errors instead of accepting that kind of crappy Liquid.

```
> toLiquidHTMLAST(`{% echo var } error! { %}`, { mode: 'strict' }) 
LiquidHTMLParsingError: 
  Expected "%}", "-%}", "}}", "-}}", a space, "|", ".", or "["
```

## Consequences

Nothing in prettier-plugin-liquid; but, in theme-check-js, this should be enough to power the `LiquidSyntaxError` check.
