### PR TITLE
Enable .twig file extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ const languages: SupportLanguage[] = [
   {
     name: 'LiquidHTML',
     parsers: [liquidHtmlLanguageName],
-    extensions: ['.liquid'],
-    vscodeLanguageIds: ['liquid', 'Liquid'],
+    extensions: ['.liquid', '.twig'],
+    vscodeLanguageIds: ['liquid', 'Liquid', 'twig', 'Twig'],
   },
 ];
 


### PR DESCRIPTION
# Motivation
- The Liquid template engine shares the basic with the [TWIG](https://twig.symfony.com) templating.

- There is no working code formatter out there for TWIG. The only alternative is the [melody](https://github.com/trivago/prettier-plugin-twig-melody) project from Trivago, but it is outdated, not maintained - and full of known bugs.

---

- Would you consider enabling the `.twig` extension for the library per default?

We have been successfully using a simple fork of the `v0.4` with enabled `.twig` extension in production since last fall for about a dozen projects. 👍 

I do understand that it is not the scope of this project to support TWIG and there will never be an official support. 
But enabling the plugin for TWIG per default would be extremely valuable for those using it.

Thanks for the consideration.

