### PR TITLE
Add completion mode

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -484,3 +484,18 @@ StrictLiquidHTML <: LiquidHTML {
   liquidTag := liquidTagStrict
   liquidTagOpen := liquidTagOpenStrict
 }
+
+WithPlaceholderLiquid <: Liquid {
+  liquidTagName := (letter | "█") (alnum | "_")*
+  variableSegment := (letter | "_" | "█") identifierCharacter*
+}
+
+WithPlaceholderLiquidStatement <: LiquidStatement {
+  liquidTagName := (letter | "█") (alnum | "_")*
+  variableSegment := (letter | "_" | "█") identifierCharacter*
+}
+
+WithPlaceholderLiquidHTML <: LiquidHTML {
+  liquidTagName := (letter | "█") (alnum | "_")*
+  variableSegment := (letter | "_" | "█") identifierCharacter*
+}

--- a/src/parser/grammar.ts
+++ b/src/parser/grammar.ts
@@ -4,16 +4,28 @@ export const liquidHtmlGrammars = ohm.grammars(
   require('../../grammar/liquid-html.ohm.js'),
 );
 
-export const strictGrammars = {
+export interface LiquidGrammars {
+  Liquid: ohm.Grammar;
+  LiquidHTML: ohm.Grammar;
+  LiquidStatement: ohm.Grammar;
+}
+
+export const strictGrammars: LiquidGrammars = {
   Liquid: liquidHtmlGrammars['StrictLiquid'],
   LiquidHTML: liquidHtmlGrammars['StrictLiquidHTML'],
   LiquidStatement: liquidHtmlGrammars['StrictLiquidStatement'],
 };
 
-export const tolerantGrammars = {
+export const tolerantGrammars: LiquidGrammars = {
   Liquid: liquidHtmlGrammars['Liquid'],
   LiquidHTML: liquidHtmlGrammars['LiquidHTML'],
   LiquidStatement: liquidHtmlGrammars['LiquidStatement'],
+};
+
+export const placeholderGrammars: LiquidGrammars = {
+  Liquid: liquidHtmlGrammars['WithPlaceholderLiquid'],
+  LiquidHTML: liquidHtmlGrammars['WithPlaceholderLiquidHTML'],
+  LiquidStatement: liquidHtmlGrammars['WithPlaceholderLiquidStatement'],
 };
 
 // see ../../grammar/liquid-html.ohm for full list

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -545,7 +545,7 @@ interface ASTBuildOptions {
    * 'tolerant' is the default case so that prettier can pretty print nodes
    * that it doesn't understand.
    */
-  mode: 'strict' | 'tolerant';
+  mode: 'strict' | 'tolerant' | 'completion';
 }
 
 export function isBranchedTag(node: LiquidHtmlNode) {


### PR DESCRIPTION
`toLiquidHtmlAST` and `toLiquidAST` now both accept the `{ mode: 'completion' }` option.

This lets us add █ characters in places where it would otherwise be impossible to "partially" parse.

Stuff like the following will be parseable:
- `{% █ %}`,
- `{{ █ }}`,
- `{{ var.█ }}`,
- `{{ var[█] }}`,
- `{{ var | █ }}`,
- `{{ var | replace: █ }}`.

Which will empower us to complete those areas without having a partial string to complete.
