### PR TITLE
Add support for prettier 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         node-version: [16.x, 17.x]
+        prettier-major: [2, 3]
 
-    name: OS ${{ matrix.os }} / NodeJS ${{ matrix.node-version }}
+    name: OS ${{ matrix.os }} / NodeJS ${{ matrix.node-version }} / Prettier ${{ matrix.prettier-major }}
+
+    env:
+      PRETTIER_MAJOR: ${{ matrix.prettier-major }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,15 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx pretty-quick --staged --pattern 'src/**/*.ts'
+cleanup() {
+  rm node_modules/prettier
+}
+
+# format with prettier2
+ln -s ./prettier2 node_modules/prettier
+
+# cleanup when done
+trap cleanup EXIT
+
+# pretty-quick on code base
+pretty-quick --staged --pattern 'src/**/*.ts'

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,4 +1,4 @@
 {
-  "require": ["./build/shims", "ts-node/register/transpile-only", "tsconfig-paths/register"],
+  "require": ["./build/shims", "./test/test-setup", "ts-node/register/transpile-only", "tsconfig-paths/register"],
   "reporter": "spec"
 }

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@
 
 [Prettier](https://prettier.io) is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.
 
-**This is the developer preview** of the Liquid/HTML prettier plugin.
-
 ![demo](https://github.com/Shopify/prettier-plugin-liquid/blob/main/docs/demo.gif?raw=true)
 
 ## Can this be used in production?

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "prerelease": "scripts/prerelease",
     "prettier": "prettier --plugin . --parser=liquid-html",
     "test": "node_modules/.bin/mocha '{src,test}/**/*.spec.ts'",
+    "test:3": "cross-env PRETTIER_MAJOR=3 yarn test",
     "test:idempotence": "cross-env TEST_IDEMPOTENCE=true node_modules/.bin/mocha 'test/**/*.spec.ts'",
+    "test:idempotence:3": "cross-env PRETTIER_MAJOR=3 yarn test:idempotence",
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -58,8 +60,10 @@
     "cross-env": "^7.0.3",
     "husky": "^7.0.0",
     "mocha": "^9.1.3",
+    "module-alias": "^2.2.3",
     "nyc": "^15.1.0",
-    "prettier": "^2.6.1",
+    "prettier2": "npm:prettier@^2.6.1",
+    "prettier3": "npm:prettier@^3.0.0",
     "pretty-quick": "^3.1.3",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import {
-  Plugin,
   RequiredOptions,
   SupportLanguage,
   SupportOptions,
+  version,
 } from 'prettier';
+import type { Plugin as Plugin2 } from 'prettier';
+import type { Plugin as Plugin3 } from 'prettier3';
 import { parsers, liquidHtmlLanguageName } from '~/parser';
-import { printers } from '~/printer';
+import { printers2, printers3 } from '~/printer';
 import { LiquidHtmlNode } from '~/types';
 
 const languages: SupportLanguage[] = [
@@ -50,16 +52,26 @@ const options: SupportOptions = {
   },
 };
 
-const defaultOptions: Partial<RequiredOptions> = {
+const defaultOptions = {
   printWidth: 120,
 };
 
-const plugin: Plugin<LiquidHtmlNode> = {
+const plugin2: Plugin2<LiquidHtmlNode> = {
   languages,
-  parsers,
-  printers,
+  parsers: parsers as Plugin2['parsers'],
+  printers: printers2,
   options,
   defaultOptions,
 };
 
-export = plugin;
+const plugin3: Plugin3<LiquidHtmlNode> = {
+  languages,
+  parsers: parsers as Plugin3['parsers'],
+  printers: printers3 as any,
+  options,
+  defaultOptions,
+};
+
+const prettierMajor = version.split('.')[0]!;
+
+export = prettierMajor === '2' ? plugin2 : plugin3;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,5 +1,4 @@
 import {
-  Parsers,
   liquidHtmlParser,
   liquidHtmlAstFormat,
   liquidHtmlLanguageName,
@@ -9,6 +8,6 @@ export * from '~/parser/stage-2-ast';
 
 export { liquidHtmlLanguageName, liquidHtmlAstFormat };
 
-export const parsers: Parsers = {
+export const parsers = {
   [liquidHtmlLanguageName]: liquidHtmlParser,
 };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,12 +1,7 @@
-import { Parser, ParserOptions } from 'prettier';
 import { locEnd, locStart } from '~/utils';
 import { toLiquidHtmlAST, LiquidHtmlNode } from '~/parser/stage-2-ast';
 
-export function parse(
-  text: string,
-  _parsers: Parsers,
-  _opts: ParserOptions<LiquidHtmlNode>,
-): LiquidHtmlNode {
+export function parse(text: string): LiquidHtmlNode {
   return toLiquidHtmlAST(text);
 }
 
@@ -14,13 +9,9 @@ export const liquidHtmlAstFormat = 'liquid-html-ast';
 
 export const liquidHtmlLanguageName = 'liquid-html';
 
-export const liquidHtmlParser: Parser<LiquidHtmlNode> = {
+export const liquidHtmlParser = {
   parse,
   astFormat: liquidHtmlAstFormat,
   locStart,
   locEnd,
 };
-
-export interface Parsers {
-  [languageName: string]: Parser;
-}

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -433,7 +433,7 @@ export interface ConcreteNumberLiteral
 export interface ConcreteLiquidLiteral
   extends ConcreteBasicNode<ConcreteNodeTypes.LiquidLiteral> {
   keyword: keyof typeof LiquidLiteralValues;
-  value: typeof LiquidLiteralValues[keyof typeof LiquidLiteralValues];
+  value: (typeof LiquidLiteralValues)[keyof typeof LiquidLiteralValues];
 }
 
 export interface ConcreteLiquidRange

--- a/src/printer/embed.ts
+++ b/src/printer/embed.ts
@@ -1,4 +1,6 @@
-import { Printer, doc } from 'prettier';
+import { doc } from 'prettier';
+import type { Printer as Printer2 } from 'prettier';
+import type { Doc as Doc3, Printer as Printer3 } from 'prettier3';
 import { RawMarkupKinds } from '~/parser';
 import { LiquidHtmlNode, LiquidParserOptions, NodeTypes } from '~/types';
 
@@ -13,7 +15,10 @@ export const ParserMap: { [key in RawMarkupKinds]: string | null } = {
   [RawMarkupKinds.text]: null,
 };
 
-export const embed: Printer<LiquidHtmlNode>['embed'] = (
+// Prettier 2 and 3 have a slightly different API for embed.
+//
+// https://github.com/prettier/prettier/wiki/How-to-migrate-my-plugin-to-support-Prettier-v3%3F
+export const embed2: Printer2<LiquidHtmlNode>['embed'] = (
   path,
   _print,
   textToDoc,
@@ -27,7 +32,8 @@ export const embed: Printer<LiquidHtmlNode>['embed'] = (
         return doc.utils.stripTrailingHardline(
           textToDoc(node.value, {
             ...options,
-            singleQuote: (options as LiquidParserOptions).embeddedSingleQuote,
+            singleQuote: (options as any as LiquidParserOptions)
+              .embeddedSingleQuote,
             parser,
             __embeddedInHtml: true,
           }),
@@ -37,4 +43,27 @@ export const embed: Printer<LiquidHtmlNode>['embed'] = (
     default:
       return null;
   }
+};
+
+export const embed3: Printer3<LiquidHtmlNode>['embed'] = (path, options) => {
+  return (textToDoc) => {
+    const node = path.node as LiquidHtmlNode;
+    switch (node.type) {
+      case NodeTypes.RawMarkup: {
+        const parser = ParserMap[node.kind];
+        if (parser && node.value.trim() !== '') {
+          return textToDoc(node.value, {
+            ...options,
+            singleQuote: (options as LiquidParserOptions).embeddedSingleQuote,
+            parser,
+            __embeddedInHtml: true,
+          }).then((document) =>
+            doc.utils.stripTrailingHardline(document),
+          ) as Promise<Doc3>;
+        }
+      }
+      default:
+        return undefined;
+    }
+  };
 };

--- a/src/printer/index.ts
+++ b/src/printer/index.ts
@@ -1,6 +1,13 @@
-import { printerLiquidHtml } from '~/printer/printer-liquid-html';
+import {
+  printerLiquidHtml2,
+  printerLiquidHtml3,
+} from '~/printer/printer-liquid-html';
 import { liquidHtmlAstFormat } from '~/parser';
 
-export const printers = {
-  [liquidHtmlAstFormat]: printerLiquidHtml,
+export const printers2 = {
+  [liquidHtmlAstFormat]: printerLiquidHtml2,
+};
+
+export const printers3 = {
+  [liquidHtmlAstFormat]: printerLiquidHtml3,
 };

--- a/src/printer/preprocess/augment-with-whitespace-helpers.ts
+++ b/src/printer/preprocess/augment-with-whitespace-helpers.ts
@@ -423,7 +423,7 @@ type ParentNode = Extract<AugmentedAstNode, { children?: AugmentedAstNode[] }>;
 
 type HtmlNode = Extract<
   AugmentedAstNode,
-  { type: typeof HtmlNodeTypes[number] }
+  { type: (typeof HtmlNodeTypes)[number] }
 >;
 
 export function isHtmlNode(node: AugmentedAstNode): node is HtmlNode {
@@ -432,7 +432,7 @@ export function isHtmlNode(node: AugmentedAstNode): node is HtmlNode {
 
 type LiquidNode = Extract<
   AugmentedAstNode,
-  { type: typeof LiquidNodeTypes[number] }
+  { type: (typeof LiquidNodeTypes)[number] }
 >;
 
 export function isLiquidNode(

--- a/src/printer/print/children.ts
+++ b/src/printer/print/children.ts
@@ -1,12 +1,13 @@
-import { AstPath, doc } from 'prettier';
+import { doc } from 'prettier';
 import { locStart, locEnd } from '~/utils';
 import {
-  NodeTypes,
-  LiquidHtmlNode,
+  AstPath,
   LiquidAstPath,
+  LiquidHtmlNode,
   LiquidParserOptions,
   LiquidPrinter,
   LiquidPrinterArgs,
+  NodeTypes,
 } from '~/types';
 import {
   FORCE_BREAK_GROUP_ID,
@@ -33,7 +34,7 @@ import {
 const {
   builders: { breakParent, group, ifBreak, line, softline, hardline },
 } = doc;
-const { replaceTextEndOfLine } = doc.utils as any;
+const { replaceEndOfLine } = doc.utils as any;
 
 function printChild(
   childPath: LiquidAstPath,
@@ -80,7 +81,7 @@ function printChild(
 
     return [
       printOpeningTagPrefix(child, options),
-      ...replaceTextEndOfLine(rawContent),
+      ...replaceEndOfLine(rawContent),
       printClosingTagSuffix(child, options),
     ];
   }
@@ -166,7 +167,7 @@ interface WhitespaceBetweenNode {
   /**
    * @doc Leading, doesn't break content
    */
-  leadingHardlines: typeof hardline[];
+  leadingHardlines: (typeof hardline)[];
 
   /**
    * @doc Leading, breaks first if content doesn't fit.
@@ -186,7 +187,7 @@ interface WhitespaceBetweenNode {
   /**
    * @doc Trailing, doesn't break content
    */
-  trailingHardlines: typeof hardline[];
+  trailingHardlines: (typeof hardline)[];
 }
 
 // This code is adapted from prettier's language-html plugin.
@@ -259,11 +260,11 @@ export function printChildren(
     ): WhitespaceBetweenNode => {
       const childNode = childPath.getValue();
 
-      const leadingHardlines: typeof hardline[] = [];
+      const leadingHardlines: (typeof hardline)[] = [];
       const leadingWhitespace: Whitespace[] = [];
       const leadingDependentWhitespace: doc.builders.Softline[] = [];
       const trailingWhitespace: Whitespace[] = [];
-      const trailingHardlines: typeof hardline[] = [];
+      const trailingHardlines: (typeof hardline)[] = [];
 
       const prevBetweenLine = printBetweenLine(childNode.prev, childNode);
       const nextBetweenLine = printBetweenLine(childNode, childNode.next);

--- a/src/printer/print/element.ts
+++ b/src/printer/print/element.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { AstPath, doc, Doc } from 'prettier';
+import { doc, Doc } from 'prettier';
 import {
   shouldPreserveContent,
   forceBreakContent,
@@ -17,6 +17,7 @@ import {
 } from '~/printer/print/tag';
 import { printChildren } from '~/printer/print/children';
 import {
+  AstPath,
   NodeTypes,
   LiquidParserOptions,
   LiquidPrinter,
@@ -37,7 +38,7 @@ const {
     softline,
   },
 } = doc;
-const { replaceTextEndOfLine } = doc.utils as any;
+const { replaceEndOfLine } = doc.utils as any;
 
 export function printRawElement(
   path: AstPath<HtmlRawNode>,
@@ -101,7 +102,7 @@ export function printElement(
       group(printOpeningTag(path, options, print, attrGroupId), {
         id: attrGroupId,
       }),
-      ...replaceTextEndOfLine(getNodeContent(node, options)),
+      ...replaceEndOfLine(getNodeContent(node, options)),
       ...printClosingTag(node, options),
       printClosingTagSuffix(node, options),
     ];

--- a/src/printer/print/liquid.ts
+++ b/src/printer/print/liquid.ts
@@ -1,5 +1,6 @@
-import { AstPath, Doc, doc } from 'prettier';
+import { Doc, doc } from 'prettier';
 import {
+  AstPath,
   LiquidAstPath,
   LiquidBranch,
   LiquidDrop,
@@ -42,7 +43,7 @@ const LIQUID_TAGS_THAT_ALWAYS_BREAK = ['for', 'case'];
 const { builders, utils } = doc;
 const { group, hardline, ifBreak, indent, join, line, softline, literalline } =
   builders;
-const { replaceTextEndOfLine } = doc.utils as any;
+const { replaceEndOfLine } = doc.utils as any;
 
 export function printLiquidDrop(
   path: LiquidAstPath,
@@ -420,7 +421,7 @@ export function printLiquidTag(
         leadingSpaceGroupId,
         trailingSpaceGroupId: FORCE_FLAT_GROUP_ID,
       }),
-      ...replaceTextEndOfLine(getNodeContent(node)),
+      ...replaceEndOfLine(getNodeContent(node)),
       printLiquidBlockEnd(path, options, print, {
         ...args,
         leadingSpaceGroupId: FORCE_FLAT_GROUP_ID,

--- a/src/printer/print/tag.ts
+++ b/src/printer/print/tag.ts
@@ -1,5 +1,6 @@
-import { AstPath, Doc, doc } from 'prettier';
+import { Doc, doc } from 'prettier';
 import {
+  AstPath,
   HtmlDanglingMarkerOpen,
   HtmlDanglingMarkerClose,
   HtmlElement,
@@ -35,7 +36,7 @@ import {
 const {
   builders: { breakParent, indent, join, line, softline, hardline },
 } = doc;
-const { replaceTextEndOfLine } = doc.utils as any;
+const { replaceEndOfLine } = doc.utils as any;
 
 export function printClosingTag(
   node: LiquidHtmlNode,
@@ -318,7 +319,7 @@ function printAttributes(
     : line;
 
   const attributes = prettierIgnoreAttributes
-    ? replaceTextEndOfLine(
+    ? replaceEndOfLine(
         node.source.slice(
           first(node.attributes).position.start,
           last(node.attributes).position.end,

--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -1,4 +1,6 @@
-import { Printer, AstPath, Doc, doc } from 'prettier';
+import { doc, Doc } from 'prettier';
+import type { Printer as Printer2 } from 'prettier';
+import type { Printer as Printer3 } from 'prettier3';
 import {
   AttrDoubleQuoted,
   AttrEmpty,
@@ -25,6 +27,7 @@ import {
   Position,
   TextNode,
   nonTraversableProperties,
+  AstPath,
 } from '~/types';
 import { assertNever } from '~/utils';
 
@@ -48,7 +51,7 @@ import {
   printLiquidTag,
 } from '~/printer/print/liquid';
 import { printChildren } from '~/printer/print/children';
-import { embed } from '~/printer/embed';
+import { embed2, embed3 } from '~/printer/embed';
 import { RawMarkupKinds } from '~/parser';
 import { getConditionalComment } from '~/parser/conditional-comment';
 
@@ -587,11 +590,25 @@ function printNode(
   }
 }
 
-export const printerLiquidHtml: Printer<LiquidHtmlNode> & {
+export const printerLiquidHtml2: Printer2<LiquidHtmlNode> & {
   preprocess: any;
 } & { getVisitorKeys: any } = {
-  print: printNode,
-  embed,
+  print: printNode as any,
+  embed: embed2,
+  preprocess,
+  getVisitorKeys(node: any, nonTraversableKeys: Set<string>) {
+    return Object.keys(node).filter(
+      (key) =>
+        !nonTraversableKeys.has(key) && !nonTraversableProperties.has(key),
+    );
+  },
+};
+
+export const printerLiquidHtml3: Printer3<LiquidHtmlNode> & {
+  preprocess: any;
+} & { getVisitorKeys: any } = {
+  print: printNode as any,
+  embed: embed3,
   preprocess,
   getVisitorKeys(node: any, nonTraversableKeys: Set<string>) {
     return Object.keys(node).filter(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,17 @@
-import { Doc, AstPath, ParserOptions } from 'prettier';
+import { Doc } from 'prettier';
+import type { AstPath as AstPath2 } from 'prettier';
+import type {
+  AstPath as AstPath3,
+  ParserOptions as ParserOptions3,
+} from 'prettier3';
 import * as AST from '~/parser/stage-2-ast';
+
+export type CommonKeys<T1, T2> = Extract<keyof T1, keyof T2>;
+export type AstPath<T = any> = Pick<
+  AstPath2<T>,
+  CommonKeys<AstPath2<T>, AstPath3<T>>
+>;
+export type ParserOptions<T = any> = ParserOptions3<T>;
 
 export interface Position {
   start: number;

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,0 +1,13 @@
+const moduleAlias = require('module-alias')
+const path = require('path');
+
+const prettierMajor = process.env.PRETTIER_MAJOR;
+const prettierPath = process.env.PRETTIER_MAJOR === '3'
+  ? path.join(__dirname, '..', 'node_modules', 'prettier3')
+  : path.join(__dirname, '..', 'node_modules', 'prettier2')
+
+moduleAlias.addAlias('prettier', prettierPath);
+
+console.error('====================================')
+console.error(`Prettier version: ${require('prettier').version}`)
+console.error('====================================')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,6 +1747,11 @@ mocha@^9.1.3:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+module-alias@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.3.tgz#ec2e85c68973bda6ab71ce7c93b763ec96053221"
+  integrity sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==
+
 mri@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -1973,10 +1978,15 @@ plimit-lit@^1.2.6:
   dependencies:
     queue-lit "^1.2.7"
 
-prettier@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
-  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+"prettier2@npm:prettier@^2.6.1":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+"prettier3@npm:prettier@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-quick@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
We still support prettier2, but we now accept prettier3 as a peer dependency as well.

Fixes #87
Fixes #194
