### PR TITLE
Fix issue #171

### DIFF
--- a/src/printer/printer-liquid-html.ts
+++ b/src/printer/printer-liquid-html.ts
@@ -273,7 +273,8 @@ function printNode(
       };
 
       if (isRawMarkupIdentationSensitive()) {
-        return node.value;
+        // trim surrounding new lines
+        return node.value.trim();
       }
 
       const lines = bodyLines(node.value);

--- a/test/issue-171/fixed.liquid
+++ b/test/issue-171/fixed.liquid
@@ -1,0 +1,26 @@
+It should not add new lines
+<script>
+  ({{ a }});
+  ``;
+</script>
+
+It should not fail on missing new line after opening script tag.
+<script>
+  ({{ a }});
+  ``;
+</script>
+
+It should not fail on missing new line before closing script tag.
+<script>
+  ({{ a }});
+  ``;
+</script>
+
+It should consume extra surrounding spaces.
+<script>
+  ({{ a }});
+  ``;
+</script>
+
+It should not fail on blank input.
+<script></script>

--- a/test/issue-171/index.liquid
+++ b/test/issue-171/index.liquid
@@ -1,0 +1,23 @@
+It should not add new lines
+<script>
+  ({{ a }});
+  ``;
+</script>
+
+It should not fail on missing new line after opening script tag.
+<script>({{ a }});
+  ``;</script>
+
+It should not fail on missing new line before closing script tag.
+<script>
+({{ a }});
+  ``;</script>
+
+It should consume extra surrounding spaces.
+<script>
+   ({{ a }});
+  ``;   
+   </script>
+
+It should not fail on blank input.
+<script></script>

--- a/test/issue-171/index.spec.ts
+++ b/test/issue-171/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
The issue is due to the plugin treating an HtmlRawNode as preformatted text not to be touched the moment it detects the \`  character (for template literals) anywhere in the body. Aside from not formatting the contents, it doesn't strip the leading and trailing newlines resulting in compounding new lines everytime prettier is run against the file. This fixes the compounding line issue in particular but does not fix the contents not being prettified when a ` is detected anywhere in the text.